### PR TITLE
Removal of master/slave words

### DIFF
--- a/cinder/api/contrib/extended_snapshot_attributes.py
+++ b/cinder/api/contrib/extended_snapshot_attributes.py
@@ -34,7 +34,7 @@ class ExtendedSnapshotAttributesController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['cinder.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             snapshot = resp_obj.obj['snapshot']
             self._extend_snapshot(req, snapshot)
 
@@ -42,7 +42,7 @@ class ExtendedSnapshotAttributesController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['cinder.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             for snapshot in list(resp_obj.obj['snapshots']):
                 self._extend_snapshot(req, snapshot)
 

--- a/cinder/api/openstack/wsgi.py
+++ b/cinder/api/openstack/wsgi.py
@@ -518,7 +518,7 @@ class ResponseObject(object):
         self.serializer = serializer()
 
     def attach(self, **kwargs):
-        """Attach slave templates to serializers."""
+        """Attach subordinate templates to serializers."""
 
         if self.media_type in kwargs:
             self.serializer.attach(kwargs[self.media_type])

--- a/cinder/backup/driver.py
+++ b/cinder/backup/driver.py
@@ -151,7 +151,7 @@ class BackupMetadataAPI(base.Base):
 
         If fields is empty list, the full set is returned.
 
-        :param metadata: master set of metadata
+        :param metadata: main set of metadata
         :param fields: list of fields we want to extract
         :param excludes: fields to be excluded
         :returns: filtered metadata

--- a/cinder/tests/unit/volume/drivers/ibm/test_storwize_svc.py
+++ b/cinder/tests/unit/volume/drivers/ibm/test_storwize_svc.py
@@ -332,7 +332,7 @@ class StorwizeSVCManagementSimulator(object):
             'wwpn',
             'primary',
             'consistgrp',
-            'master',
+            'main',
             'aux',
             'cluster',
             'linkbandwidthmbits',
@@ -340,7 +340,7 @@ class StorwizeSVCManagementSimulator(object):
             'copies',
             'cyclingmode',
             'cycleperiodseconds',
-            'masterchange',
+            'mainchange',
             'auxchange',
         ]
         no_or_one_param_args = [
@@ -1868,16 +1868,16 @@ port_speed!N/A
     # Replication related command
     # Create a remote copy
     def _cmd_mkrcrelationship(self, **kwargs):
-        master_vol = ''
+        main_vol = ''
         aux_vol = ''
         aux_cluster = ''
-        master_sys = self._system_list['storwize-svc-sim']
+        main_sys = self._system_list['storwize-svc-sim']
         aux_sys = self._system_list['aux-svc-sim']
 
-        if 'master' not in kwargs:
+        if 'main' not in kwargs:
             return self._errors['CMMVC5707E']
-        master_vol = kwargs['master'].strip('\'\"')
-        if master_vol not in self._volumes_list:
+        main_vol = kwargs['main'].strip('\'\"')
+        if main_vol not in self._volumes_list:
             return self._errors['CMMVC5754E']
 
         if 'aux' not in kwargs:
@@ -1892,7 +1892,7 @@ port_speed!N/A
         if aux_cluster != aux_sys['name']:
             return self._errors['CMMVC5754E']
 
-        if (self._volumes_list[master_vol]['capacity'] !=
+        if (self._volumes_list[main_vol]['capacity'] !=
                 self._volumes_list[aux_vol]['capacity']):
             return self._errors['CMMVC5754E']
 
@@ -1903,15 +1903,15 @@ port_speed!N/A
         rcrel_info = {}
         rcrel_info['id'] = self._find_unused_id(self._rcrelationship_list)
         rcrel_info['name'] = 'rcrel' + rcrel_info['id']
-        rcrel_info['master_cluster_id'] = master_sys['id']
-        rcrel_info['master_cluster_name'] = master_sys['name']
-        rcrel_info['master_vdisk_id'] = self._volumes_list[master_vol]['id']
-        rcrel_info['master_vdisk_name'] = master_vol
+        rcrel_info['main_cluster_id'] = main_sys['id']
+        rcrel_info['main_cluster_name'] = main_sys['name']
+        rcrel_info['main_vdisk_id'] = self._volumes_list[main_vol]['id']
+        rcrel_info['main_vdisk_name'] = main_vol
         rcrel_info['aux_cluster_id'] = aux_sys['id']
         rcrel_info['aux_cluster_name'] = aux_sys['name']
         rcrel_info['aux_vdisk_id'] = self._volumes_list[aux_vol]['id']
         rcrel_info['aux_vdisk_name'] = aux_vol
-        rcrel_info['primary'] = 'master'
+        rcrel_info['primary'] = 'main'
         rcrel_info['consistency_group_id'] = ''
         rcrel_info['consistency_group_name'] = ''
         rcrel_info['state'] = 'inconsistent_stopped'
@@ -1923,14 +1923,14 @@ port_speed!N/A
         rcrel_info['copy_type'] = 'global' if 'global' in kwargs else 'metro'
         rcrel_info['cycling_mode'] = cyclingmode if cyclingmode else ''
         rcrel_info['cycle_period_seconds'] = '300'
-        rcrel_info['master_change_vdisk_id'] = ''
-        rcrel_info['master_change_vdisk_name'] = ''
+        rcrel_info['main_change_vdisk_id'] = ''
+        rcrel_info['main_change_vdisk_name'] = ''
         rcrel_info['aux_change_vdisk_id'] = ''
         rcrel_info['aux_change_vdisk_name'] = ''
 
         self._rcrelationship_list[rcrel_info['name']] = rcrel_info
-        self._volumes_list[master_vol]['RC_name'] = rcrel_info['name']
-        self._volumes_list[master_vol]['RC_id'] = rcrel_info['id']
+        self._volumes_list[main_vol]['RC_name'] = rcrel_info['name']
+        self._volumes_list[main_vol]['RC_id'] = rcrel_info['id']
         self._volumes_list[aux_vol]['RC_name'] = rcrel_info['name']
         self._volumes_list[aux_vol]['RC_id'] = rcrel_info['id']
         return('RC Relationship, id [' + rcrel_info['id'] +
@@ -1955,11 +1955,11 @@ port_speed!N/A
 
                     rows.append(['id', v['id']])
                     rows.append(['name', v['name']])
-                    rows.append(['master_cluster_id', v['master_cluster_id']])
-                    rows.append(['master_cluster_name',
-                                v['master_cluster_name']])
-                    rows.append(['master_vdisk_id', v['master_vdisk_id']])
-                    rows.append(['master_vdisk_name', v['master_vdisk_name']])
+                    rows.append(['main_cluster_id', v['main_cluster_id']])
+                    rows.append(['main_cluster_name',
+                                v['main_cluster_name']])
+                    rows.append(['main_vdisk_id', v['main_vdisk_id']])
+                    rows.append(['main_vdisk_name', v['main_vdisk_name']])
                     rows.append(['aux_cluster_id', v['aux_cluster_id']])
                     rows.append(['aux_cluster_name', v['aux_cluster_name']])
                     rows.append(['aux_vdisk_id', v['aux_vdisk_id']])
@@ -1979,10 +1979,10 @@ port_speed!N/A
                     rows.append(['cycling_mode', v['cycling_mode']])
                     rows.append(['cycle_period_seconds',
                                  v['cycle_period_seconds']])
-                    rows.append(['master_change_vdisk_id',
-                                 v['master_change_vdisk_id']])
-                    rows.append(['master_change_vdisk_name',
-                                 v['master_change_vdisk_name']])
+                    rows.append(['main_change_vdisk_id',
+                                 v['main_change_vdisk_id']])
+                    rows.append(['main_change_vdisk_name',
+                                 v['main_change_vdisk_name']])
                     rows.append(['aux_change_vdisk_id',
                                  v['aux_change_vdisk_id']])
                     rows.append(['aux_change_vdisk_name',
@@ -2066,8 +2066,8 @@ port_speed!N/A
         function = 'delete_force' if force else 'delete'
         self._rc_state_transition(function, rcrel)
         if rcrel['state'] == 'end':
-            self._volumes_list[rcrel['master_vdisk_name']]['RC_name'] = ''
-            self._volumes_list[rcrel['master_vdisk_name']]['RC_id'] = ''
+            self._volumes_list[rcrel['main_vdisk_name']]['RC_name'] = ''
+            self._volumes_list[rcrel['main_vdisk_name']]['RC_id'] = ''
             self._volumes_list[rcrel['aux_vdisk_name']]['RC_name'] = ''
             self._volumes_list[rcrel['aux_vdisk_name']]['RC_id'] = ''
             del self._rcrelationship_list[id_num]
@@ -2085,9 +2085,9 @@ port_speed!N/A
             return self._errors['CMMVC5753E']
 
         nonull_num = 0
-        masterchange = None
-        if 'masterchange' in kwargs:
-            masterchange = kwargs['masterchange'].strip('\'\"')
+        mainchange = None
+        if 'mainchange' in kwargs:
+            mainchange = kwargs['mainchange'].strip('\'\"')
             nonull_num += 1
 
         auxchange = None
@@ -2102,8 +2102,8 @@ port_speed!N/A
 
         if nonull_num > 1:
             return self._errors['CMMVC5713E']
-        elif masterchange:
-            rcrel['master_change_vdisk_name'] = masterchange
+        elif mainchange:
+            rcrel['main_change_vdisk_name'] = mainchange
             return ('', '')
         elif auxchange:
             rcrel['aux_change_vdisk_name'] = auxchange
@@ -2138,10 +2138,10 @@ port_speed!N/A
 
     def _cmd_lspartnershipcandidate(self, **kwargs):
         rows = [None] * 4
-        master_sys = self._system_list['storwize-svc-sim']
+        main_sys = self._system_list['storwize-svc-sim']
         aux_sys = self._system_list['aux-svc-sim']
         rows[0] = ['id', 'configured', 'name']
-        rows[1] = [master_sys['id'], 'no', master_sys['name']]
+        rows[1] = [main_sys['id'], 'no', main_sys['name']]
         rows[2] = [aux_sys['id'], 'no', aux_sys['name']]
         rows[3] = ['0123456789001234', 'no', 'fake_svc']
         return self._print_info_cmd(rows=rows, **kwargs)
@@ -2151,11 +2151,11 @@ port_speed!N/A
         rows.append(['id', 'name', 'location', 'partnership',
                      'type', 'cluster_ip', 'event_log_sequence'])
 
-        master_sys = self._system_list['storwize-svc-sim']
-        if master_sys['name'] not in self._partnership_list:
+        main_sys = self._system_list['storwize-svc-sim']
+        if main_sys['name'] not in self._partnership_list:
             local_info = {}
-            local_info['id'] = master_sys['id']
-            local_info['name'] = master_sys['name']
+            local_info['id'] = main_sys['id']
+            local_info['name'] = main_sys['name']
             local_info['location'] = 'local'
             local_info['type'] = ''
             local_info['cluster_ip'] = ''
@@ -2164,7 +2164,7 @@ port_speed!N/A
             local_info['linkbandwidthmbits'] = ''
             local_info['backgroundcopyrate'] = ''
             local_info['partnership'] = ''
-            self._partnership_list[master_sys['id']] = local_info
+            self._partnership_list[main_sys['id']] = local_info
 
         # Assume we always get a filtervalue argument
         filter_key = kwargs['filtervalue'].split('=')[0]
@@ -2179,7 +2179,7 @@ port_speed!N/A
     def _cmd_mkippartnership(self, **kwargs):
         if 'clusterip' not in kwargs:
             return self._errors['CMMVC5707E']
-        clusterip = kwargs['master'].strip('\'\"')
+        clusterip = kwargs['main'].strip('\'\"')
 
         if 'linkbandwidthmbits' not in kwargs:
             return self._errors['CMMVC5707E']
@@ -4313,29 +4313,29 @@ class StorwizeSVCCommonDriverTestCase(test.TestCase):
 
     def test_storwize_svc_delete_volume_snapshots(self):
         # Create a volume with two snapshots
-        master = self._create_volume()
+        main = self._create_volume()
 
         # Fail creating a snapshot - will force delete the snapshot
         if self.USESIM and False:
-            snap = self._generate_snap_info(master.id)
+            snap = self._generate_snap_info(main.id)
             self.sim.error_injection('startfcmap', 'bad_id')
             self.assertRaises(exception.VolumeBackendAPIException,
                               self.driver.create_snapshot, snap)
             self._assert_vol_exists(snap['name'], False)
 
         # Delete a snapshot
-        snap = self._generate_snap_info(master.id)
+        snap = self._generate_snap_info(main.id)
         self.driver.create_snapshot(snap)
         self._assert_vol_exists(snap['name'], True)
         self.driver.delete_snapshot(snap)
         self._assert_vol_exists(snap['name'], False)
 
         # Delete a volume with snapshots (regular)
-        snap = self._generate_snap_info(master.id)
+        snap = self._generate_snap_info(main.id)
         self.driver.create_snapshot(snap)
         self._assert_vol_exists(snap['name'], True)
-        self.driver.delete_volume(master)
-        self._assert_vol_exists(master['name'], False)
+        self.driver.delete_volume(main)
+        self._assert_vol_exists(main['name'], False)
 
         # Fail create volume from snapshot - will force delete the volume
         if self.USESIM:
@@ -6245,7 +6245,7 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
 
         self.driver._get_storwize_config()
         self.assertEqual(self.driver._helpers,
-                         self.driver._master_backend_helpers)
+                         self.driver._main_backend_helpers)
         self.assertEqual(self.driver._replica_enabled, False)
 
         self.driver._get_storwize_config()
@@ -6345,15 +6345,15 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
             self.assertEqual(storwize_const.GMCV_MULTI, cycling_mode)
             self.assertEqual(storwize_const.GLOBAL, vol_rep_type)
             self.assertEqual(storwize_const.GMCV, rep_type)
-            self.assertEqual('master', rel_info['primary'])
-            self.assertEqual(volume['name'], rel_info['master_vdisk_name'])
+            self.assertEqual('main', rel_info['primary'])
+            self.assertEqual(volume['name'], rel_info['main_vdisk_name'])
             self.assertEqual(
                 storwize_const.REPLICA_AUX_VOL_PREFIX + volume['name'],
                 rel_info['aux_vdisk_name'])
             self.assertEqual('inconsistent_copying', rel_info['state'])
             self.assertEqual(
                 storwize_const.REPLICA_CHG_VOL_PREFIX + volume['name'],
-                rel_info['master_change_vdisk_name'])
+                rel_info['main_change_vdisk_name'])
             self.assertEqual(
                 storwize_const.REPLICA_CHG_VOL_PREFIX +
                 storwize_const.REPLICA_AUX_VOL_PREFIX + volume['name'],
@@ -6367,8 +6367,8 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
                 self.ctxt, volume)
             self.assertEqual(rep_type, vol_rep_type)
 
-            self.assertEqual('master', rel_info['primary'])
-            self.assertEqual(volume['name'], rel_info['master_vdisk_name'])
+            self.assertEqual('main', rel_info['primary'])
+            self.assertEqual(volume['name'], rel_info['main_vdisk_name'])
             self.assertEqual(
                 storwize_const.REPLICA_AUX_VOL_PREFIX + volume['name'],
                 rel_info['aux_vdisk_name'])
@@ -6400,11 +6400,11 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         self.assertEqual(storwize_const.GMCV,
                          self.driver._get_volume_replicated_type(
                              self.ctxt, volume))
-        self.assertEqual('master', rel_info['primary'])
-        self.assertEqual(volume['name'], rel_info['master_vdisk_name'])
+        self.assertEqual('main', rel_info['primary'])
+        self.assertEqual(volume['name'], rel_info['main_vdisk_name'])
         self.assertEqual((storwize_const.REPLICA_CHG_VOL_PREFIX
                           + volume['name']),
-                         rel_info['master_change_vdisk_name'])
+                         rel_info['main_change_vdisk_name'])
         aux_vdisk_name = (storwize_const.REPLICA_AUX_VOL_PREFIX
                           + volume['name'])
         self.assertEqual(aux_vdisk_name,
@@ -6863,7 +6863,7 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         self.assertEqual(fields.ReplicationStatus.ENABLED,
                          model_update['replication_status'])
 
-        uid_of_master = self._get_vdisk_uid(rep_volume['name'])
+        uid_of_main = self._get_vdisk_uid(rep_volume['name'])
         uid_of_aux = self._get_vdisk_uid(
             storwize_const.REPLICA_AUX_VOL_PREFIX + rep_volume['name'])
 
@@ -6874,10 +6874,10 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         self.driver.manage_existing(new_volume, ref)
 
         # Check the uid of the volume which has been renamed.
-        uid_of_master_volume = self._get_vdisk_uid(new_volume['name'])
+        uid_of_main_volume = self._get_vdisk_uid(new_volume['name'])
         uid_of_aux_volume = self._get_vdisk_uid(
             storwize_const.REPLICA_AUX_VOL_PREFIX + new_volume['name'])
-        self.assertEqual(uid_of_master, uid_of_master_volume)
+        self.assertEqual(uid_of_main, uid_of_main_volume)
         self.assertEqual(uid_of_aux, uid_of_aux_volume)
 
         self.driver.delete_volume(rep_volume)
@@ -6887,8 +6887,8 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         self.assertEqual(fields.ReplicationStatus.ENABLED,
                          model_update['replication_status'])
 
-        uid_of_master = self._get_vdisk_uid(rep_volume['name'])
-        uid_of_master_change = self._get_vdisk_uid(
+        uid_of_main = self._get_vdisk_uid(rep_volume['name'])
+        uid_of_main_change = self._get_vdisk_uid(
             storwize_const.REPLICA_CHG_VOL_PREFIX +
             rep_volume['name'])
         uid_of_aux = self._get_vdisk_uid(
@@ -6906,8 +6906,8 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         self.driver.manage_existing(new_volume, ref)
 
         # Check the uid of the volume which has been renamed.
-        uid_of_new_master = self._get_vdisk_uid(new_volume['name'])
-        uid_of_new_master_change = self._get_vdisk_uid(
+        uid_of_new_main = self._get_vdisk_uid(new_volume['name'])
+        uid_of_new_main_change = self._get_vdisk_uid(
             storwize_const.REPLICA_CHG_VOL_PREFIX +
             new_volume['name'])
         uid_of_new_aux = self._get_vdisk_uid(
@@ -6918,9 +6918,9 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
             storwize_const.REPLICA_AUX_VOL_PREFIX +
             new_volume['name'])
 
-        self.assertEqual(uid_of_master, uid_of_new_master)
+        self.assertEqual(uid_of_main, uid_of_new_main)
         self.assertEqual(uid_of_aux, uid_of_new_aux)
-        self.assertEqual(uid_of_master_change, uid_of_new_master_change)
+        self.assertEqual(uid_of_main_change, uid_of_new_main_change)
         self.assertEqual(uid_of_aux_change, uid_of_new_aux_change)
 
         self.driver.delete_volume(rep_volume)
@@ -7024,9 +7024,9 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         self.driver._helpers.delete_rc_volume(fake_name)
         get_relationship_info.assert_called_once_with(fake_name)
         delete_relationship.assert_called_once_with(fake_name)
-        master_change_fake_name = (
+        main_change_fake_name = (
             storwize_const.REPLICA_CHG_VOL_PREFIX + fake_name)
-        calls = [mock.call(master_change_fake_name, False),
+        calls = [mock.call(main_change_fake_name, False),
                  mock.call(fake_name, False)]
         delete_vdisk.assert_has_calls(calls, any_order=True)
         self.assertEqual(2, delete_vdisk.call_count)
@@ -7551,14 +7551,14 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
              'id': '0'}]
 
         rep_mgr = self.driver._get_replica_mgr()
-        rep_mgr._partnership_start(rep_mgr._master_helpers,
+        rep_mgr._partnership_start(rep_mgr._main_helpers,
                                    'storwize-svc-sim')
         self.assertFalse(chpartnership.called)
-        rep_mgr._partnership_start(rep_mgr._master_helpers,
+        rep_mgr._partnership_start(rep_mgr._main_helpers,
                                    'storwize-svc-sim')
         self.assertFalse(chpartnership.called)
 
-        rep_mgr._partnership_start(rep_mgr._master_helpers,
+        rep_mgr._partnership_start(rep_mgr._main_helpers,
                                    'storwize-svc-sim')
         chpartnership.assert_called_once_with('0')
 
@@ -7576,7 +7576,7 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         volumes = [mm_vol, gmcv_vol]
 
         fake_info = {'volume': 'fake',
-                     'master_vdisk_name': 'fake',
+                     'main_vdisk_name': 'fake',
                      'aux_vdisk_name': 'fake'}
         sync_state = {'state': storwize_const.REP_CONSIS_SYNC,
                       'primary': 'fake'}
@@ -7587,7 +7587,7 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         sync_copying_state.update(fake_info)
 
         disconn_state = {'state': storwize_const.REP_IDL_DISC,
-                         'primary': 'master'}
+                         'primary': 'main'}
         disconn_state.update(fake_info)
         stop_state = {'state': storwize_const.REP_CONSIS_STOP,
                       'primary': 'aux'}
@@ -7642,7 +7642,7 @@ class StorwizeSVCReplicationTestCase(test.TestCase):
         gmcv_vol = self._generate_vol_info(self.gmcv_with_cps900_type)
 
         fake_info = {'volume': 'fake',
-                     'master_vdisk_name': 'fake',
+                     'main_vdisk_name': 'fake',
                      'aux_vdisk_name': 'fake',
                      'primary': 'fake'}
         sync_state = {'state': storwize_const.REP_CONSIS_SYNC}

--- a/cinder/tests/unit/volume/drivers/ibm/test_xiv_proxy.py
+++ b/cinder/tests/unit/volume/drivers/ibm/test_xiv_proxy.py
@@ -448,7 +448,7 @@ class XIVProxyTest(test.TestCase):
                 mock.MagicMock(return_value=False))
     @mock.patch("cinder.volume.drivers.ibm.ibm_storage."
                 "xiv_proxy.XIVProxy._get_target_params",
-                mock.MagicMock(return_value={'san_clustername': "master"}))
+                mock.MagicMock(return_value={'san_clustername': "main"}))
     @mock.patch("cinder.volume.drivers.ibm.ibm_storage."
                 "xiv_proxy.XIVProxy._init_xcli",
                 mock.MagicMock())
@@ -484,7 +484,7 @@ class XIVProxyTest(test.TestCase):
                 mock.MagicMock(return_value=True))
     @mock.patch("cinder.volume.drivers.ibm.ibm_storage."
                 "xiv_proxy.XIVProxy._get_target_params",
-                mock.MagicMock(return_value={'san_clustername': "master"}))
+                mock.MagicMock(return_value={'san_clustername': "main"}))
     @mock.patch("cinder.volume.drivers.ibm.ibm_storage."
                 "xiv_proxy.XIVProxy._init_xcli",
                 mock.MagicMock())
@@ -579,7 +579,7 @@ class XIVProxyTest(test.TestCase):
 
         failover_rep_mgr.change_role.assert_called_once_with(
             resource_id=group['name'],
-            new_role='Slave')
+            new_role='Subordinate')
 
     @mock.patch("cinder.volume.utils.is_group_a_cg_snapshot_type",
                 mock.MagicMock(return_value=True))

--- a/cinder/tests/unit/volume/drivers/test_hgst.py
+++ b/cinder/tests/unit/volume/drivers/test_hgst.py
@@ -753,7 +753,7 @@ IP_OUTPUT = """
        valid_lft forever preferred_lft forever
     inet6 ::1/128 scope host
        valid_lft forever preferred_lft forever
-2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master
+2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq main
     link/ether 00:25:90:d9:18:08 brd ff:ff:ff:ff:ff:ff
     inet6 fe80::225:90ff:fed9:1808/64 scope link
        valid_lft forever preferred_lft forever
@@ -804,7 +804,7 @@ HGST_HOST_STORAGE = """
         "ipDataProviderLoaded": true,
         "ibDataProviderLoaded": false,
         "driverUptimeSecs": 4800,
-        "rVersion": "20368.d55ec22.master"
+        "rVersion": "20368.d55ec22.main"
       },
       "totalCapacityBytes": 98213822464,
       "totalUsedBytes": 3266781184,
@@ -824,7 +824,7 @@ HGST_HOST_STORAGE = """
         "ipDataProviderLoaded": true,
         "ibDataProviderLoaded": false,
         "driverUptimeSecs": 0,
-        "rVersion": "20368.d55ec22.master"
+        "rVersion": "20368.d55ec22.main"
       },
       "totalCapacityBytes": 0,
       "totalUsedBytes": 0,

--- a/cinder/volume/drivers/hitachi/hbsd_fc.py
+++ b/cinder/volume/drivers/hitachi/hbsd_fc.py
@@ -169,11 +169,11 @@ class HBSDFCDriver(cinder.volume.driver.FibreChannelDriver):
                 if added_hostgroup:
                     self._delete_hostgroup(port, gid, host_grp_name)
 
-    def add_hostgroup_master(self, hgs, master_wwns, host_ip, security_ports):
+    def add_hostgroup_main(self, hgs, main_wwns, host_ip, security_ports):
         target_ports = self.configuration.hitachi_target_ports
         group_request = self.configuration.hitachi_group_request
         wwns = []
-        for wwn in master_wwns:
+        for wwn in main_wwns:
             wwns.append(wwn.lower())
         if target_ports and group_request:
             host_grp_name = '%s%s' % (basic_lib.NAME_PREFIX, host_ip)
@@ -241,7 +241,7 @@ class HBSDFCDriver(cinder.volume.driver.FibreChannelDriver):
         hostgroups = []
         security_ports = self._get_hostgroup_info(
             hostgroups, properties['wwpns'], login=False)
-        self.add_hostgroup_master(hostgroups, properties['wwpns'],
+        self.add_hostgroup_main(hostgroups, properties['wwpns'],
                                   properties['ip'], security_ports)
         self.add_hostgroup_pair(self.pair_hostgroups)
 
@@ -386,7 +386,7 @@ class HBSDFCDriver(cinder.volume.driver.FibreChannelDriver):
             hostgroups = []
             security_ports = self._get_hostgroup_info(
                 hostgroups, connector['wwpns'], login=True)
-            self.add_hostgroup_master(hostgroups, connector['wwpns'],
+            self.add_hostgroup_main(hostgroups, connector['wwpns'],
                                       connector['ip'], security_ports)
 
         if src_hgs is self.pair_hostgroups:

--- a/cinder/volume/drivers/hitachi/hbsd_iscsi.py
+++ b/cinder/volume/drivers/hitachi/hbsd_iscsi.py
@@ -211,12 +211,12 @@ class HBSDISCSIDriver(cinder.volume.driver.ISCSIDriver):
         if ports:
             self._fill_groups(hgs, ports, target_iqn, target_alias, add_iqn)
 
-    def add_hostgroup_master(self, hgs, master_iqn, host_ip, security_ports):
+    def add_hostgroup_main(self, hgs, main_iqn, host_ip, security_ports):
         target_ports = self.configuration.hitachi_target_ports
         group_request = self.configuration.hitachi_group_request
         target_alias = '%s%s' % (basic_lib.NAME_PREFIX, host_ip)
         if target_ports and group_request:
-            target_iqn = '%s.target' % master_iqn
+            target_iqn = '%s.target' % main_iqn
 
             diff_ports = []
             for port in security_ports:
@@ -227,7 +227,7 @@ class HBSDISCSIDriver(cinder.volume.driver.ISCSIDriver):
                     diff_ports.append(port)
 
             self.add_hostgroup_core(hgs, diff_ports, target_iqn,
-                                    target_alias, master_iqn)
+                                    target_alias, main_iqn)
         if not hgs:
             raise exception.HBSDError(message=basic_lib.output_err(649))
 
@@ -240,7 +240,7 @@ class HBSDISCSIDriver(cinder.volume.driver.ISCSIDriver):
         hostgroups = []
         security_ports = self._get_hostgroup_info_iscsi(
             hostgroups, properties['initiator'])
-        self.add_hostgroup_master(hostgroups, properties['initiator'],
+        self.add_hostgroup_main(hostgroups, properties['initiator'],
                                   properties['ip'], security_ports)
 
     def _get_properties(self, volume, hostgroups):
@@ -337,7 +337,7 @@ class HBSDISCSIDriver(cinder.volume.driver.ISCSIDriver):
             hostgroups = []
             security_ports = self._get_hostgroup_info_iscsi(
                 hostgroups, connector['initiator'])
-            self.add_hostgroup_master(hostgroups, connector['initiator'],
+            self.add_hostgroup_main(hostgroups, connector['initiator'],
                                       connector['ip'], security_ports)
 
         self._add_target(hostgroups, ldev)

--- a/cinder/volume/drivers/ibm/ibm_storage/xiv_proxy.py
+++ b/cinder/volume/drivers/ibm/ibm_storage/xiv_proxy.py
@@ -682,7 +682,7 @@ class XIVProxy(proxy.IBMStorageProxy):
                 data=msg)
         return secondary_backend_id
 
-    def check_for_splitbrain(self, volumes, pool_master, pool_slave):
+    def check_for_splitbrain(self, volumes, pool_main, pool_subordinate):
         if volumes:
             # check for split brain situations
             # check for files that are available on both volumes
@@ -690,8 +690,8 @@ class XIVProxy(proxy.IBMStorageProxy):
             split_brain = self._potential_split_brain(
                 self.ibm_storage_cli,
                 self.ibm_storage_remote_cli,
-                volumes, pool_master,
-                pool_slave)
+                volumes, pool_main,
+                pool_subordinate)
             if split_brain:
                 # if such a situation exists stop and raise an exception!
                 msg = (_("A potential split brain condition has been found "
@@ -710,7 +710,7 @@ class XIVProxy(proxy.IBMStorageProxy):
         """
         volumes_updated = []
         goal_status = ''
-        pool_master = None
+        pool_main = None
         group_updated = {'replication_status': group.replication_status}
         LOG.info("failover_replication: of cg %(cg)s "
                  "from %(active)s to %(id)s",
@@ -723,10 +723,10 @@ class XIVProxy(proxy.IBMStorageProxy):
                 LOG.info("CG has been failed back. "
                          "No need to fail back again.")
                 return group_updated, volumes_updated
-            # get the master pool, not using default id.
-            pool_master = self._get_target_params(
+            # get the main pool, not using default id.
+            pool_main = self._get_target_params(
                 self.active_backend_id)['san_clustername']
-            pool_slave = self.storage_info[storage.FLAG_KEYS['storage_pool']]
+            pool_subordinate = self.storage_info[storage.FLAG_KEYS['storage_pool']]
             goal_status = 'enabled'
             vol_goal_status = 'available'
         else:
@@ -737,8 +737,8 @@ class XIVProxy(proxy.IBMStorageProxy):
             # replciation_device entry. so we use get_targets.
             secondary_backend_id = self.get_secondary_backend_id(
                 secondary_backend_id)
-            pool_master = self.storage_info[storage.FLAG_KEYS['storage_pool']]
-            pool_slave = self._get_target_params(
+            pool_main = self.storage_info[storage.FLAG_KEYS['storage_pool']]
+            pool_subordinate = self._get_target_params(
                 secondary_backend_id)['san_clustername']
             goal_status = fields.ReplicationStatus.FAILED_OVER
             vol_goal_status = fields.ReplicationStatus.FAILED_OVER
@@ -746,7 +746,7 @@ class XIVProxy(proxy.IBMStorageProxy):
         self.ibm_storage_remote_cli = self._init_xcli(secondary_backend_id)
 
         # check for split brain in mirrored volumes
-        self.check_for_splitbrain(volumes, pool_master, pool_slave)
+        self.check_for_splitbrain(volumes, pool_main, pool_subordinate)
         group_specs = group_types.get_group_type_specs(group.group_type_id)
         if group_specs is None:
             msg = "No group specs found. Cannot failover."
@@ -1338,43 +1338,43 @@ class XIVProxy(proxy.IBMStorageProxy):
         return ((self.active_backend_id is None) or
                 (self.active_backend_id == strings.PRIMARY_BACKEND_ID))
 
-    def _is_vol_split_brain(self, xcli_master, xcli_slave, vol):
-        mirror_master = xcli_master.cmd.mirror_list(vol=vol).as_list
-        mirror_slave = xcli_slave.cmd.mirror_list(vol=vol).as_list
-        if (len(mirror_master) == 1 and len(mirror_slave) == 1 and
-            mirror_master[0].current_role == 'Master' and
-            mirror_slave[0].current_role == 'Slave' and
-                mirror_master[0].sync_state.lower() in SYNCHED_STATES):
+    def _is_vol_split_brain(self, xcli_main, xcli_subordinate, vol):
+        mirror_main = xcli_main.cmd.mirror_list(vol=vol).as_list
+        mirror_subordinate = xcli_subordinate.cmd.mirror_list(vol=vol).as_list
+        if (len(mirror_main) == 1 and len(mirror_subordinate) == 1 and
+            mirror_main[0].current_role == 'Main' and
+            mirror_subordinate[0].current_role == 'Subordinate' and
+                mirror_main[0].sync_state.lower() in SYNCHED_STATES):
             return False
         else:
             return True
 
-    def _potential_split_brain(self, xcli_master, xcli_slave,
-                               volumes, pool_master, pool_slave):
+    def _potential_split_brain(self, xcli_main, xcli_subordinate,
+                               volumes, pool_main, pool_subordinate):
         potential_split_brain = []
-        if xcli_master is None or xcli_slave is None:
+        if xcli_main is None or xcli_subordinate is None:
             return potential_split_brain
         try:
-            vols_master = xcli_master.cmd.vol_list(
-                pool=pool_master).as_dict('name')
+            vols_main = xcli_main.cmd.vol_list(
+                pool=pool_main).as_dict('name')
         except Exception:
             msg = "Failed getting information from the active storage."
             LOG.debug(msg)
             return potential_split_brain
         try:
-            vols_slave = xcli_slave.cmd.vol_list(
-                pool=pool_slave).as_dict('name')
+            vols_subordinate = xcli_subordinate.cmd.vol_list(
+                pool=pool_subordinate).as_dict('name')
         except Exception:
             msg = "Failed getting information from the target storage."
             LOG.debug(msg)
             return potential_split_brain
 
         vols_requested = set(vol['name'] for vol in volumes)
-        common_vols = set(vols_master).intersection(
-            set(vols_slave)).intersection(set(vols_requested))
+        common_vols = set(vols_main).intersection(
+            set(vols_subordinate)).intersection(set(vols_requested))
         for name in common_vols:
-            if self._is_vol_split_brain(xcli_master=xcli_master,
-                                        xcli_slave=xcli_slave, vol=name):
+            if self._is_vol_split_brain(xcli_main=xcli_main,
+                                        xcli_subordinate=xcli_subordinate, vol=name):
                 potential_split_brain.append(name)
         return potential_split_brain
 
@@ -1400,8 +1400,8 @@ class XIVProxy(proxy.IBMStorageProxy):
                 LOG.info("Host has been failed back. No need "
                          "to fail back again.")
                 return self.active_backend_id, volume_update_list, []
-            pool_slave = self.storage_info[storage.FLAG_KEYS['storage_pool']]
-            pool_master = self._get_target_params(
+            pool_subordinate = self.storage_info[storage.FLAG_KEYS['storage_pool']]
+            pool_main = self._get_target_params(
                 self.active_backend_id)['san_clustername']
             goal_status = 'available'
         else:
@@ -1410,16 +1410,16 @@ class XIVProxy(proxy.IBMStorageProxy):
                 return self.active_backend_id, volume_update_list, []
             # case: need to select a target
             secondary_id = self.get_secondary_backend_id(secondary_id)
-            pool_master = self.storage_info[storage.FLAG_KEYS['storage_pool']]
+            pool_main = self.storage_info[storage.FLAG_KEYS['storage_pool']]
             try:
-                pool_slave = self._get_target_params(
+                pool_subordinate = self._get_target_params(
                     secondary_id)['san_clustername']
             except Exception:
                 msg = _("Invalid target information. Can't perform failover")
                 LOG.error(msg)
                 raise self.meta['exception'].VolumeBackendAPIException(
                     data=msg)
-            pool_master = self.storage_info[storage.FLAG_KEYS['storage_pool']]
+            pool_main = self.storage_info[storage.FLAG_KEYS['storage_pool']]
             goal_status = fields.ReplicationStatus.FAILED_OVER
 
         # connnect xcli to secondary storage according to backend_id by
@@ -1431,7 +1431,7 @@ class XIVProxy(proxy.IBMStorageProxy):
             # check for split brain situations
             # check for files that are available on both volumes
             # and are not in an active mirroring relation
-            self.check_for_splitbrain(volumes, pool_master, pool_slave)
+            self.check_for_splitbrain(volumes, pool_main, pool_subordinate)
 
         # loop over volumes and attempt failover
         for volume in volumes:

--- a/cinder/volume/drivers/ibm/ibm_storage/xiv_replication.py
+++ b/cinder/volume/drivers/ibm/ibm_storage/xiv_replication.py
@@ -200,7 +200,7 @@ class Replication(object):
             recovery_mgr.switch_roles(resource_id=resource['name'])
             return True, None
         except Exception as e:
-            # failed attempt to switch_roles from the master
+            # failed attempt to switch_roles from the main
             details = self.proxy._get_code_and_status_or_message(e)
             LOG.warning('Failed to perform switch_roles on'
                         ' %(res)s: %(err)s. '
@@ -209,9 +209,9 @@ class Replication(object):
         try:
             # this is the ugly stage we come to brute force
             if failback:
-                role = 'Slave'
+                role = 'Subordinate'
             else:
-                role = 'Master'
+                role = 'Main'
             LOG.warning('Attempt to change_role to %(role)s', {'role': role})
             failover_rep_mgr.change_role(resource_id=resource['name'],
                                          new_role=role)
@@ -259,13 +259,13 @@ class VolumeReplication(Replication):
                 resource_name=resource_name,
                 target_name=target,
                 mirror_type=replication_info['mode'],
-                slave_resource_name=resource_name,
-                create_slave='yes',
+                subordinate_resource_name=resource_name,
+                create_subordinate='yes',
                 remote_pool=pool,
                 rpo=replication_info['rpo'],
                 schedule=schedule,
                 activate_mirror='yes')
-        except errors.VolumeMasterError:
+        except errors.VolumeMainError:
             LOG.debug('Volume %(vol)s has been already mirrored',
                       {'vol': resource_name})
         except Exception as e:
@@ -281,8 +281,8 @@ class VolumeReplication(Replication):
 
         Attempts to failover a single volume
         Sequence:
-        1. attempt to switch roles from master
-        2. attempt to change role to master on secondary
+        1. attempt to switch roles from main
+        2. attempt to change role to main on secondary
 
         returns (success, failure_reason)
         """
@@ -321,7 +321,7 @@ class GroupReplication(Replication):
                 resource_name=resource_name,
                 target_name=target,
                 mirror_type=replication_info['mode'],
-                slave_resource_name=resource_name,
+                subordinate_resource_name=resource_name,
                 rpo=replication_info['rpo'],
                 schedule=schedule,
                 activate_mirror='yes')

--- a/cinder/volume/drivers/ibm/storwize_svc/storwize_svc_common.py
+++ b/cinder/volume/drivers/ibm/storwize_svc/storwize_svc_common.py
@@ -311,9 +311,9 @@ class StorwizeSSH(object):
             with excutils.save_and_reraise_exception():
                 LOG.error('Error mapping VDisk-to-host')
 
-    def mkrcrelationship(self, master, aux, system, asyncmirror,
+    def mkrcrelationship(self, main, aux, system, asyncmirror,
                          cyclingmode=False):
-        ssh_cmd = ['svctask', 'mkrcrelationship', '-master', master,
+        ssh_cmd = ['svctask', 'mkrcrelationship', '-main', main,
                    '-aux', aux, '-cluster', system]
         if asyncmirror:
             ssh_cmd.append('-global')
@@ -329,7 +329,7 @@ class StorwizeSSH(object):
         self.run_ssh_assert_no_output(ssh_cmd)
 
     def switchrelationship(self, relationship, aux=True):
-        primary = 'aux' if aux else 'master'
+        primary = 'aux' if aux else 'main'
         ssh_cmd = ['svctask', 'switchrcrelationship', '-primary',
                    primary, relationship]
         self.run_ssh_assert_no_output(ssh_cmd)
@@ -353,13 +353,13 @@ class StorwizeSSH(object):
             self.run_ssh_assert_no_output(ssh_cmd)
 
     def ch_rcrelationship_changevolume(self, relationship,
-                                       changevolume, master):
+                                       changevolume, main):
         # Note: Can only change one attribute at a time,
         # so define two ch_rcrelationship_xxx here
         if changevolume:
             ssh_cmd = ['svctask', 'chrcrelationship']
-            if master:
-                ssh_cmd.extend(['-masterchange', changevolume])
+            if main:
+                ssh_cmd.extend(['-mainchange', changevolume])
             else:
                 ssh_cmd.extend(['-auxchange', changevolume])
             ssh_cmd.append(relationship)
@@ -1721,39 +1721,39 @@ class StorwizeHelpers(object):
         if vol_attrs['RC_name']:
             self.ssh.stoprcrelationship(vol_attrs['RC_name'], access=access)
 
-    def create_relationship(self, master, aux, system, asyncmirror,
-                            cyclingmode=False, masterchange=None,
+    def create_relationship(self, main, aux, system, asyncmirror,
+                            cyclingmode=False, mainchange=None,
                             cycle_period_seconds=None):
         try:
-            rc_id = self.ssh.mkrcrelationship(master, aux, system,
+            rc_id = self.ssh.mkrcrelationship(main, aux, system,
                                               asyncmirror, cyclingmode)
         except exception.VolumeBackendAPIException as e:
             # CMMVC5959E is the code in Stowize storage, meaning that
             # there is a relationship that already has this name on the
-            # master cluster.
+            # main cluster.
             if 'CMMVC5959E' not in e:
                 # If there is no relation between the primary and the
                 # secondary back-end storage, the exception is raised.
                 raise
         if rc_id:
-            # We need setup master and aux change volumes for gmcv
+            # We need setup main and aux change volumes for gmcv
             # before we can start remote relationship
             # aux change volume must be set on target site
             if cycle_period_seconds:
-                self.change_relationship_cycleperiod(master,
+                self.change_relationship_cycleperiod(main,
                                                      cycle_period_seconds)
-            if masterchange:
-                self.change_relationship_changevolume(master,
-                                                      masterchange, True)
+            if mainchange:
+                self.change_relationship_changevolume(main,
+                                                      mainchange, True)
             else:
-                self.start_relationship(master)
+                self.start_relationship(main)
 
     def change_relationship_changevolume(self, volume_name,
-                                         change_volume, master):
+                                         change_volume, main):
         vol_attrs = self.get_vdisk_attributes(volume_name)
         if vol_attrs['RC_name'] and change_volume:
             self.ssh.ch_rcrelationship_changevolume(vol_attrs['RC_name'],
-                                                    change_volume, master)
+                                                    change_volume, main)
 
     def change_relationship_cycleperiod(self, volume_name,
                                         cycle_period_seconds):
@@ -2164,9 +2164,9 @@ class StorwizeSVCCommonDriver(san.SanDriver,
         self._backend_name = self.configuration.safe_get('volume_backend_name')
         self.active_ip = self.configuration.san_ip
         self.inactive_ip = self.configuration.storwize_san_secondary_ip
-        self._master_backend_helpers = StorwizeHelpers(self._run_ssh)
+        self._main_backend_helpers = StorwizeHelpers(self._run_ssh)
         self._aux_backend_helpers = None
-        self._helpers = self._master_backend_helpers
+        self._helpers = self._main_backend_helpers
         self._vdiskcopyops = {}
         self._vdiskcopyops_loop = None
         self.protocol = None
@@ -2507,16 +2507,16 @@ class StorwizeSVCCommonDriver(san.SanDriver,
                 self._aux_backend_helpers.delete_rc_volume(volume['name'],
                                                            target_vol=True)
             if not self._active_backend_id:
-                self._master_backend_helpers.delete_rc_volume(volume['name'])
+                self._main_backend_helpers.delete_rc_volume(volume['name'])
             else:
                 # If it's in fail over state, also try to delete the volume
-                # in master backend
+                # in main backend
                 try:
-                    self._master_backend_helpers.delete_rc_volume(
+                    self._main_backend_helpers.delete_rc_volume(
                         volume['name'])
                 except Exception as ex:
                     LOG.error('Failed to get delete volume %(volume)s in '
-                              'master backend. Exception: %(err)s.',
+                              'main backend. Exception: %(err)s.',
                               {'volume': volume['name'],
                                'err': ex})
         else:
@@ -2678,11 +2678,11 @@ class StorwizeSVCCommonDriver(san.SanDriver,
             try:
                 rep_type = rel_info['copy_type']
                 cyclingmode = rel_info['cycling_mode']
-                self._master_backend_helpers.delete_relationship(
+                self._main_backend_helpers.delete_relationship(
                     volume.name)
                 tgt_vol = (storwize_const.REPLICA_AUX_VOL_PREFIX +
                            volume.name)
-                self._master_backend_helpers.extend_vdisk(volume.name,
+                self._main_backend_helpers.extend_vdisk(volume.name,
                                                           extend_amt)
                 self._aux_backend_helpers.extend_vdisk(tgt_vol, extend_amt)
                 tgt_sys = self._aux_backend_helpers.get_system_info()
@@ -2693,7 +2693,7 @@ class StorwizeSVCCommonDriver(san.SanDriver,
                     source_change_vol = (
                         storwize_const.REPLICA_CHG_VOL_PREFIX +
                         volume.name)
-                    self._master_backend_helpers.extend_vdisk(
+                    self._main_backend_helpers.extend_vdisk(
                         source_change_vol, extend_amt)
                     self._aux_backend_helpers.extend_vdisk(
                         tgt_change_vol, extend_amt)
@@ -2701,15 +2701,15 @@ class StorwizeSVCCommonDriver(san.SanDriver,
                         volume.volume_type_id)
                     cycle_period_seconds = src_change_opts.get(
                         'cycle_period_seconds')
-                    self._master_backend_helpers.create_relationship(
+                    self._main_backend_helpers.create_relationship(
                         volume.name, tgt_vol, tgt_sys.get('system_name'),
                         True, True, source_change_vol, cycle_period_seconds)
                     self._aux_backend_helpers.change_relationship_changevolume(
                         tgt_vol, tgt_change_vol, False)
-                    self._master_backend_helpers.start_relationship(
+                    self._main_backend_helpers.start_relationship(
                         volume.name)
                 else:
-                    self._master_backend_helpers.create_relationship(
+                    self._main_backend_helpers.create_relationship(
                         volume.name, tgt_vol, tgt_sys.get('system_name'),
                         True if storwize_const.GLOBAL == rep_type else False)
             except Exception as e:
@@ -2871,7 +2871,7 @@ class StorwizeSVCCommonDriver(san.SanDriver,
             return None, volumes_update
 
         try:
-            self._master_backend_helpers.get_system_info()
+            self._main_backend_helpers.get_system_info()
         except Exception:
             msg = (_("Unable to failback due to primary is not reachable."))
             LOG.error(msg)
@@ -2879,7 +2879,7 @@ class StorwizeSVCCommonDriver(san.SanDriver,
 
         unrep_volumes, rep_volumes = self._classify_volume(ctxt, volumes)
 
-        # start synchronize from aux volume to master volume
+        # start synchronize from aux volume to main volume
         self._sync_with_aux(ctxt, rep_volumes)
         self._wait_replica_ready(ctxt, rep_volumes)
 
@@ -2891,7 +2891,7 @@ class StorwizeSVCCommonDriver(san.SanDriver,
             unrep_volumes)
         volumes_update.extend(unrep_volumes_update)
 
-        self._helpers = self._master_backend_helpers
+        self._helpers = self._main_backend_helpers
         self._active_backend_id = None
 
         # Update the storwize state
@@ -2916,17 +2916,17 @@ class StorwizeSVCCommonDriver(san.SanDriver,
                           fields.ReplicationStatus.ERROR,
                           'status': 'error'}})
                 LOG.error('_failback_replica_volumes:no rc-releationship '
-                          'is established between master: %(master)s and '
+                          'is established between main: %(main)s and '
                           'aux %(aux)s. Please re-establish the '
                           'relationship and synchronize the volumes on '
                           'backend storage.',
-                          {'master': volume['name'], 'aux': tgt_volume})
+                          {'main': volume['name'], 'aux': tgt_volume})
                 continue
-            LOG.debug('_failover_replica_volumes: vol=%(vol)s, master_vol='
-                      '%(master_vol)s, aux_vol=%(aux_vol)s, state=%(state)s'
+            LOG.debug('_failover_replica_volumes: vol=%(vol)s, main_vol='
+                      '%(main_vol)s, aux_vol=%(aux_vol)s, state=%(state)s'
                       'primary=%(primary)s',
                       {'vol': volume['name'],
-                       'master_vol': rep_info['master_vdisk_name'],
+                       'main_vol': rep_info['main_vdisk_name'],
                        'aux_vol': rep_info['aux_vdisk_name'],
                        'state': rep_info['state'],
                        'primary': rep_info['primary']})
@@ -2979,17 +2979,17 @@ class StorwizeSVCCommonDriver(san.SanDriver,
             rep_info = self._helpers.get_relationship_info(tgt_volume)
             if not rep_info:
                 LOG.error('_sync_with_aux: no rc-releationship is '
-                          'established between master: %(master)s and aux '
+                          'established between main: %(main)s and aux '
                           '%(aux)s. Please re-establish the relationship '
                           'and synchronize the volumes on backend '
-                          'storage.', {'master': volume['name'],
+                          'storage.', {'main': volume['name'],
                                        'aux': tgt_volume})
                 continue
-            LOG.debug('_sync_with_aux: volume: %(volume)s rep_info:master_vol='
-                      '%(master_vol)s, aux_vol=%(aux_vol)s, state=%(state)s, '
+            LOG.debug('_sync_with_aux: volume: %(volume)s rep_info:main_vol='
+                      '%(main_vol)s, aux_vol=%(aux_vol)s, state=%(state)s, '
                       'primary=%(primary)s',
                       {'volume': volume['name'],
-                       'master_vol': rep_info['master_vdisk_name'],
+                       'main_vol': rep_info['main_vdisk_name'],
                        'aux_vol': rep_info['aux_vdisk_name'],
                        'state': rep_info['state'],
                        'primary': rep_info['primary']})
@@ -2997,17 +2997,17 @@ class StorwizeSVCCommonDriver(san.SanDriver,
                 if (rep_info['state'] not in
                         [storwize_const.REP_CONSIS_SYNC,
                          storwize_const.REP_CONSIS_COPYING]):
-                    if rep_info['primary'] == 'master':
+                    if rep_info['primary'] == 'main':
                         self._helpers.start_relationship(tgt_volume)
                     else:
                         self._helpers.start_relationship(tgt_volume,
                                                          primary='aux')
             except Exception as ex:
-                LOG.warning('Fail to copy data from aux to master. master:'
-                            ' %(master)s and aux %(aux)s. Please '
+                LOG.warning('Fail to copy data from aux to main. main:'
+                            ' %(main)s and aux %(aux)s. Please '
                             're-establish the relationship and synchronize'
                             ' the volumes on backend storage. error='
-                            '%(ex)s', {'master': volume['name'],
+                            '%(ex)s', {'main': volume['name'],
                                        'aux': tgt_volume,
                                        'error': ex})
         LOG.debug('leave: _sync_with_aux.')
@@ -3038,10 +3038,10 @@ class StorwizeSVCCommonDriver(san.SanDriver,
                 LOG.error(msg)
                 raise exception.VolumeBackendAPIException(data=msg)
             LOG.debug('_replica_vol_ready:volume: %(volume)s rep_info: '
-                      'master_vol=%(master_vol)s, aux_vol=%(aux_vol)s, '
+                      'main_vol=%(main_vol)s, aux_vol=%(aux_vol)s, '
                       'state=%(state)s, primary=%(primary)s',
                       {'volume': volume,
-                       'master_vol': rep_info['master_vdisk_name'],
+                       'main_vol': rep_info['main_vdisk_name'],
                        'aux_vol': rep_info['aux_vdisk_name'],
                        'state': rep_info['state'],
                        'primary': rep_info['primary']})
@@ -3115,17 +3115,17 @@ class StorwizeSVCCommonDriver(san.SanDriver,
                               fields.ReplicationStatus.FAILOVER_ERROR,
                               'status': 'error'}})
                     LOG.error('_failover_replica_volumes: no rc-'
-                              'releationship is established for master:'
-                              '%(master)s. Please re-establish the rc-'
+                              'releationship is established for main:'
+                              '%(main)s. Please re-establish the rc-'
                               'relationship and synchronize the volumes on'
                               ' backend storage.',
-                              {'master': volume['name']})
+                              {'main': volume['name']})
                     continue
                 LOG.debug('_failover_replica_volumes: vol=%(vol)s, '
-                          'master_vol=%(master_vol)s, aux_vol=%(aux_vol)s, '
+                          'main_vol=%(main_vol)s, aux_vol=%(aux_vol)s, '
                           'state=%(state)s, primary=%(primary)s',
                           {'vol': volume['name'],
-                           'master_vol': rep_info['master_vdisk_name'],
+                           'main_vol': rep_info['main_vdisk_name'],
                            'aux_vol': rep_info['aux_vdisk_name'],
                            'state': rep_info['state'],
                            'primary': rep_info['primary']})
@@ -3705,7 +3705,7 @@ class StorwizeSVCCommonDriver(san.SanDriver,
                                                    aux_vol)
             if storwize_const.GMCV == vol_rep_type:
                 self._helpers.rename_vdisk(
-                    rel_info['master_change_vdisk_name'],
+                    rel_info['main_change_vdisk_name'],
                     storwize_const.REPLICA_CHG_VOL_PREFIX + volume['name'])
                 self._aux_backend_helpers.rename_vdisk(
                     rel_info['aux_change_vdisk_name'],

--- a/nova/api/openstack/compute/server_groups.py
+++ b/nova/api/openstack/compute/server_groups.py
@@ -52,7 +52,7 @@ def _get_not_deleted(context, uuids):
     cell_mappings = {}
     found_inst_uuids = []
 
-    # Get a master list of cell mappings, and a list of instance
+    # Get a main list of cell mappings, and a list of instance
     # uuids organized by cell
     for im in mappings:
         if not im.cell_mapping:

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -602,7 +602,7 @@ class ComputeManager(manager.Manager):
                 return objects.InstanceList()
             filters['uuid'] = driver_uuids
             local_instances = objects.InstanceList.get_by_filters(
-                context, filters, use_slave=True)
+                context, filters, use_subordinate=True)
             return local_instances
         except NotImplementedError:
             pass
@@ -614,7 +614,7 @@ class ComputeManager(manager.Manager):
         # Without this all instance data would be fetched from db.
         filters['host'] = self.host
         instances = objects.InstanceList.get_by_filters(context, filters,
-                                                        use_slave=True)
+                                                        use_subordinate=True)
         name_map = {instance.name: instance for instance in instances}
         local_instances = []
         for driver_instance in driver_instances:
@@ -1345,7 +1345,7 @@ class ComputeManager(manager.Manager):
                    'host': self.host}
 
         building_insts = objects.InstanceList.get_by_filters(context,
-                           filters, expected_attrs=[], use_slave=True)
+                           filters, expected_attrs=[], use_subordinate=True)
 
         for instance in building_insts:
             if timeutils.is_older_than(instance.created_at, timeout):
@@ -1627,7 +1627,7 @@ class ComputeManager(manager.Manager):
         context = context.elevated()
         instances = objects.InstanceList.get_by_host(context, self.host,
                                                      expected_attrs=[],
-                                                     use_slave=True)
+                                                     use_subordinate=True)
         uuids = [instance.uuid for instance in instances]
         self.scheduler_client.sync_instance_info(context, self.host, uuids)
 
@@ -5904,7 +5904,7 @@ class ComputeManager(manager.Manager):
             # The list of instances to heal is empty so rebuild it
             LOG.debug('Rebuilding the list of instances to heal')
             db_instances = objects.InstanceList.get_by_host(
-                context, self.host, expected_attrs=[], use_slave=True)
+                context, self.host, expected_attrs=[], use_subordinate=True)
             for inst in db_instances:
                 # We don't want to refresh the cache for instances
                 # which are building or deleting so don't put them
@@ -5935,7 +5935,7 @@ class ComputeManager(manager.Manager):
                             context, instance_uuids.pop(0),
                             expected_attrs=['system_metadata', 'info_cache',
                                             'flavor'],
-                            use_slave=True)
+                            use_subordinate=True)
                 except exception.InstanceNotFound:
                     # Instance is gone.  Try to grab another.
                     continue
@@ -5986,7 +5986,7 @@ class ComputeManager(manager.Manager):
                         task_states.REBOOT_PENDING],
                        'host': self.host}
             rebooting = objects.InstanceList.get_by_filters(
-                context, filters, expected_attrs=[], use_slave=True)
+                context, filters, expected_attrs=[], use_subordinate=True)
 
             to_poll = []
             for instance in rebooting:
@@ -6003,7 +6003,7 @@ class ComputeManager(manager.Manager):
                        'host': self.host}
             rescued_instances = objects.InstanceList.get_by_filters(
                 context, filters, expected_attrs=["system_metadata"],
-                use_slave=True)
+                use_subordinate=True)
 
             to_unrescue = []
             for instance in rescued_instances:
@@ -6021,7 +6021,7 @@ class ComputeManager(manager.Manager):
 
         migrations = objects.MigrationList.get_unconfirmed_by_dest_compute(
                 context, CONF.resize_confirm_window, self.host,
-                use_slave=True)
+                use_subordinate=True)
 
         migrations_info = dict(migration_count=len(migrations),
                 confirm_window=CONF.resize_confirm_window)
@@ -6050,7 +6050,7 @@ class ComputeManager(manager.Manager):
             try:
                 instance = objects.Instance.get_by_uuid(context,
                             instance_uuid, expected_attrs=expected_attrs,
-                            use_slave=True)
+                            use_subordinate=True)
             except exception.InstanceNotFound:
                 reason = (_("Instance %s not found") %
                           instance_uuid)
@@ -6110,7 +6110,7 @@ class ComputeManager(manager.Manager):
                    'host': self.host}
         shelved_instances = objects.InstanceList.get_by_filters(
             context, filters=filters, expected_attrs=['system_metadata'],
-            use_slave=True)
+            use_subordinate=True)
 
         to_gc = []
         for instance in shelved_instances:
@@ -6143,7 +6143,7 @@ class ComputeManager(manager.Manager):
             context, begin, end, host=self.host,
             expected_attrs=['system_metadata', 'info_cache', 'metadata',
                             'flavor'],
-            use_slave=True)
+            use_subordinate=True)
         num_instances = len(instances)
         errors = 0
         successes = 0
@@ -6205,7 +6205,7 @@ class ComputeManager(manager.Manager):
 
             instances = objects.InstanceList.get_by_host(context,
                                                               self.host,
-                                                              use_slave=True)
+                                                              use_subordinate=True)
             try:
                 bw_counters = self.driver.get_all_bw_counters(instances)
             except NotImplementedError:
@@ -6229,7 +6229,7 @@ class ComputeManager(manager.Manager):
                 last_ctr_out = None
                 usage = objects.BandwidthUsage.get_by_instance_uuid_and_mac(
                     context, bw_ctr['uuid'], bw_ctr['mac_address'],
-                    start_period=start_time, use_slave=True)
+                    start_period=start_time, use_subordinate=True)
                 if usage:
                     bw_in = usage.bw_in
                     bw_out = usage.bw_out
@@ -6239,7 +6239,7 @@ class ComputeManager(manager.Manager):
                     usage = (objects.BandwidthUsage.
                              get_by_instance_uuid_and_mac(
                         context, bw_ctr['uuid'], bw_ctr['mac_address'],
-                        start_period=prev_time, use_slave=True))
+                        start_period=prev_time, use_subordinate=True))
                     if usage:
                         last_ctr_in = usage.last_ctr_in
                         last_ctr_out = usage.last_ctr_out
@@ -6269,14 +6269,14 @@ class ComputeManager(manager.Manager):
                                               last_refreshed=refreshed,
                                               update_cells=update_cells)
 
-    def _get_host_volume_bdms(self, context, use_slave=False):
+    def _get_host_volume_bdms(self, context, use_subordinate=False):
         """Return all block device mappings on a compute host."""
         compute_host_bdms = []
         instances = objects.InstanceList.get_by_host(context, self.host,
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         for instance in instances:
             bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
-                    context, instance.uuid, use_slave=use_slave)
+                    context, instance.uuid, use_subordinate=use_subordinate)
             instance_bdms = [bdm for bdm in bdms if bdm.is_volume]
             compute_host_bdms.append(dict(instance=instance,
                                           instance_bdms=instance_bdms))
@@ -6308,7 +6308,7 @@ class ComputeManager(manager.Manager):
             return
 
         compute_host_bdms = self._get_host_volume_bdms(context,
-                                                       use_slave=True)
+                                                       use_subordinate=True)
         if not compute_host_bdms:
             return
 
@@ -6334,7 +6334,7 @@ class ComputeManager(manager.Manager):
         """
         db_instances = objects.InstanceList.get_by_host(context, self.host,
                                                         expected_attrs=[],
-                                                        use_slave=True)
+                                                        use_subordinate=True)
 
         num_vm_instances = self.driver.get_num_instances()
         num_db_instances = len(db_instances)
@@ -6393,14 +6393,14 @@ class ComputeManager(manager.Manager):
             self._sync_instance_power_state(context,
                                             db_instance,
                                             vm_power_state,
-                                            use_slave=True)
+                                            use_subordinate=True)
         except exception.InstanceNotFound:
             # NOTE(hanlind): If the instance gets deleted during sync,
             # silently ignore.
             pass
 
     def _sync_instance_power_state(self, context, db_instance, vm_power_state,
-                                   use_slave=False):
+                                   use_subordinate=False):
         """Align instance power state between the database and hypervisor.
 
         If the instance is not found on the hypervisor, but is in the database,
@@ -6409,7 +6409,7 @@ class ComputeManager(manager.Manager):
 
         # We re-query the DB to get the latest instance info to minimize
         # (not eliminate) race condition.
-        db_instance.refresh(use_slave=use_slave)
+        db_instance.refresh(use_subordinate=use_subordinate)
         db_power_state = db_instance.power_state
         vm_state = db_instance.vm_state
 
@@ -6572,7 +6572,7 @@ class ComputeManager(manager.Manager):
         instances = objects.InstanceList.get_by_filters(
             context, filters,
             expected_attrs=objects.instance.INSTANCE_DEFAULT_FIELDS,
-            use_slave=True)
+            use_subordinate=True)
         for instance in instances:
             if self._deleted_old_enough(instance, interval):
                 bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
@@ -6623,7 +6623,7 @@ class ComputeManager(manager.Manager):
         """
 
         compute_nodes_in_db = self._get_compute_nodes_in_db(context,
-                                                            use_slave=True,
+                                                            use_subordinate=True,
                                                             startup=startup)
         nodenames = set(self.driver.get_available_nodes())
         for nodename in nodenames:
@@ -6644,11 +6644,11 @@ class ComputeManager(manager.Manager):
                 self.scheduler_client.reportclient.delete_resource_provider(
                     context, cn, cascade=True)
 
-    def _get_compute_nodes_in_db(self, context, use_slave=False,
+    def _get_compute_nodes_in_db(self, context, use_subordinate=False,
                                  startup=False):
         try:
             return objects.ComputeNodeList.get_all_by_host(context, self.host,
-                                                           use_slave=use_slave)
+                                                           use_subordinate=use_subordinate)
         except exception.NotFound:
             if startup:
                 LOG.warning(
@@ -6721,7 +6721,7 @@ class ComputeManager(manager.Manager):
                              "DELETED but still present on host.",
                              instance.name, instance=instance)
                     bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
-                        context, instance.uuid, use_slave=True)
+                        context, instance.uuid, use_subordinate=True)
                     self.instance_events.clear_events_for_instance(instance)
                     try:
                         self._shutdown_instance(context, instance, bdms,
@@ -6781,11 +6781,11 @@ class ComputeManager(manager.Manager):
                 self._set_instance_obj_error_state(context, instance)
 
     @wrap_exception()
-    def add_aggregate_host(self, context, aggregate, host, slave_info):
+    def add_aggregate_host(self, context, aggregate, host, subordinate_info):
         """Notify hypervisor of change (for hypervisor pools)."""
         try:
             self.driver.add_to_aggregate(context, aggregate, host,
-                                         slave_info=slave_info)
+                                         subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug('Hypervisor driver does not support '
                       'add_aggregate_host')
@@ -6797,11 +6797,11 @@ class ComputeManager(manager.Manager):
                                     aggregate, host)
 
     @wrap_exception()
-    def remove_aggregate_host(self, context, host, slave_info, aggregate):
+    def remove_aggregate_host(self, context, host, subordinate_info, aggregate):
         """Removes a host from a physical hypervisor pool."""
         try:
             self.driver.remove_from_aggregate(context, aggregate, host,
-                                              slave_info=slave_info)
+                                              subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug('Hypervisor driver does not support '
                       'remove_aggregate_host')
@@ -6961,7 +6961,7 @@ class ComputeManager(manager.Manager):
                    'soft_deleted': True,
                    'host': nodes}
         filtered_instances = objects.InstanceList.get_by_filters(context,
-                                 filters, expected_attrs=[], use_slave=True)
+                                 filters, expected_attrs=[], use_subordinate=True)
 
         self.driver.manage_image_cache(context, filtered_instances)
 
@@ -6976,7 +6976,7 @@ class ComputeManager(manager.Manager):
         attrs = ['system_metadata']
         with utils.temporary_mutation(context, read_deleted='yes'):
             instances = objects.InstanceList.get_by_filters(
-                context, filters, expected_attrs=attrs, use_slave=True)
+                context, filters, expected_attrs=attrs, use_subordinate=True)
         LOG.debug('There are %d instances to clean', len(instances))
 
         # TODO(raj_singh): Remove this if condition when min value is
@@ -7028,7 +7028,7 @@ class ComputeManager(manager.Manager):
         attrs = ['info_cache', 'security_groups', 'system_metadata']
         with utils.temporary_mutation(context, read_deleted='yes'):
             instances = objects.InstanceList.get_by_filters(
-                context, inst_filters, expected_attrs=attrs, use_slave=True)
+                context, inst_filters, expected_attrs=attrs, use_subordinate=True)
 
         for instance in instances:
             if instance.host != CONF.host:

--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -143,7 +143,7 @@ class ComputeAPI(object):
 
         * 2.0 - Remove 1.x backwards compat
         * 2.1 - Adds orig_sys_metadata to rebuild_instance()
-        * 2.2 - Adds slave_info parameter to add_aggregate_host() and
+        * 2.2 - Adds subordinate_info parameter to add_aggregate_host() and
                 remove_aggregate_host()
         * 2.3 - Adds volume_id to reserve_block_device_name()
         * 2.4 - Add bdms to terminate_instance
@@ -399,7 +399,7 @@ class ComputeAPI(object):
                               serializer=serializer)
 
     def add_aggregate_host(self, ctxt, host, aggregate, host_param,
-                           slave_info=None):
+                           subordinate_info=None):
         '''Add aggregate host.
 
         :param ctxt: request context
@@ -413,7 +413,7 @@ class ComputeAPI(object):
                 server=host, version=version)
         cctxt.cast(ctxt, 'add_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def add_fixed_ip_to_instance(self, ctxt, instance, network_id):
         version = '4.0'
@@ -815,7 +815,7 @@ class ComputeAPI(object):
                    **extra)
 
     def remove_aggregate_host(self, ctxt, host, aggregate, host_param,
-                              slave_info=None):
+                              subordinate_info=None):
         '''Remove aggregate host.
 
         :param ctxt: request context
@@ -829,7 +829,7 @@ class ComputeAPI(object):
                 server=host, version=version)
         cctxt.cast(ctxt, 'remove_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def remove_fixed_ip_from_instance(self, ctxt, instance, address):
         version = '4.0'

--- a/nova/conductor/rpcapi.py
+++ b/nova/conductor/rpcapi.py
@@ -123,7 +123,7 @@ class ConductorAPI(object):
     * 1.62 - Added object_backport()
     * 1.63 - Changed the format of values['stats'] from a dict to a JSON string
              in compute_node_update()
-    * 1.64 - Added use_slave to instance_get_all_filters()
+    * 1.64 - Added use_subordinate to instance_get_all_filters()
            - Remove instance_type_get()
            - Remove aggregate_get()
            - Remove aggregate_get_by_host()

--- a/nova/conf/database.py
+++ b/nova/conf/database.py
@@ -57,7 +57,7 @@ api_db_opts = [
     cfg.BoolOpt('sqlite_synchronous',
                 default=True,
                 help=''),
-    cfg.StrOpt('slave_connection',
+    cfg.StrOpt('subordinate_connection',
                secret=True,
                help=''),
     cfg.StrOpt('mysql_sql_mode',

--- a/nova/conf/network.py
+++ b/nova/conf/network.py
@@ -998,19 +998,19 @@ nova-network is deprecated, as are any related configuration options.
 nova-network is deprecated, as are any related configuration options.
 """,
         help="Bind user's password for LDAP server"),
-    cfg.StrOpt('ldap_dns_soa_hostmaster',
-        default='hostmaster@example.org',
+    cfg.StrOpt('ldap_dns_soa_hostmain',
+        default='hostmain@example.org',
         deprecated_for_removal=True,
         deprecated_since='16.0.0',
         deprecated_reason="""
 nova-network is deprecated, as are any related configuration options.
 """,
         help="""
-Hostmaster for LDAP DNS driver Statement of Authority
+Hostmain for LDAP DNS driver Statement of Authority
 
 Possible values:
 
-* Any valid string representing LDAP DNS hostmaster.
+* Any valid string representing LDAP DNS hostmain.
 """),
     cfg.MultiStrOpt('ldap_dns_servers',
         default=['dns.example.org'],
@@ -1048,7 +1048,7 @@ nova-network is deprecated, as are any related configuration options.
         help="""
 Refresh interval (in seconds) for LDAP DNS driver Start of Authority
 
-Time interval, a secondary/slave DNS server waits before requesting for
+Time interval, a secondary/subordinate DNS server waits before requesting for
 primary DNS server's current SOA record. If the records are different,
 secondary DNS server will request a zone transfer from primary.
 
@@ -1064,7 +1064,7 @@ nova-network is deprecated, as are any related configuration options.
         help="""
 Retry interval (in seconds) for LDAP DNS driver Start of Authority
 
-Time interval, a secondary/slave DNS server should wait, if an
+Time interval, a secondary/subordinate DNS server should wait, if an
 attempt to transfer zone failed during the previous refresh interval.
 """),
     cfg.IntOpt('ldap_dns_soa_expiry',
@@ -1077,7 +1077,7 @@ nova-network is deprecated, as are any related configuration options.
         help="""
 Expiry interval (in seconds) for LDAP DNS driver Start of Authority
 
-Time interval, a secondary/slave DNS server holds the information
+Time interval, a secondary/subordinate DNS server holds the information
 before it is no longer considered authoritative.
 """),
     cfg.IntOpt('ldap_dns_soa_minimum',

--- a/nova/conf/xvp.py
+++ b/nova/conf/xvp.py
@@ -40,7 +40,7 @@ xvp_opts = [
     cfg.StrOpt('console_xvp_pid',
                default='/var/run/xvp.pid',
                deprecated_group='DEFAULT',
-               help='XVP master process pid file'),
+               help='XVP main process pid file'),
     cfg.StrOpt('console_xvp_log',
                default='/var/log/xvp.log',
                deprecated_group='DEFAULT',

--- a/nova/db/api.py
+++ b/nova/db/api.py
@@ -92,8 +92,8 @@ def create_context_manager(connection):
 def select_db_reader_mode(f):
     """Decorator to select synchronous or asynchronous reader mode.
 
-    The kwarg argument 'use_slave' defines reader mode. Asynchronous reader
-    will be used if 'use_slave' is True and synchronous reader otherwise.
+    The kwarg argument 'use_subordinate' defines reader mode. Asynchronous reader
+    will be used if 'use_subordinate' is True and synchronous reader otherwise.
     """
     return IMPL.select_db_reader_mode(f)
 

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -82,7 +82,7 @@ api_context_manager = enginefacade.transaction_context()
 def _get_db_conf(conf_group, connection=None):
     kw = dict(
         connection=connection or conf_group.connection,
-        slave_connection=conf_group.slave_connection,
+        subordinate_connection=conf_group.subordinate_connection,
         sqlite_fk=False,
         __autocommit=True,
         expire_on_commit=False,
@@ -138,14 +138,14 @@ def get_context_manager(context):
     return _context_manager_from_context(context) or main_context_manager
 
 
-def get_engine(use_slave=False, context=None):
+def get_engine(use_subordinate=False, context=None):
     """Get a database engine object.
 
-    :param use_slave: Whether to use the slave connection
+    :param use_subordinate: Whether to use the subordinate connection
     :param context: The request context that can contain a context manager
     """
     ctxt_mgr = get_context_manager(context)
-    return ctxt_mgr.get_legacy_facade().get_engine(use_slave=use_slave)
+    return ctxt_mgr.get_legacy_facade().get_engine(use_subordinate=use_subordinate)
 
 
 def get_api_engine():
@@ -211,9 +211,9 @@ def require_aggregate_exists(f):
 def select_db_reader_mode(f):
     """Decorator to select synchronous or asynchronous reader mode.
 
-    The kwarg argument 'use_slave' defines reader mode. Asynchronous reader
-    will be used if 'use_slave' is True and synchronous reader otherwise.
-    If 'use_slave' is not specified default value 'False' will be used.
+    The kwarg argument 'use_subordinate' defines reader mode. Asynchronous reader
+    will be used if 'use_subordinate' is True and synchronous reader otherwise.
+    If 'use_subordinate' is not specified default value 'False' will be used.
 
     Wrapped function must have a context in the arguments.
     """
@@ -224,9 +224,9 @@ def select_db_reader_mode(f):
         keyed_args = inspect.getcallargs(wrapped_func, *args, **kwargs)
 
         context = keyed_args['context']
-        use_slave = keyed_args.get('use_slave', False)
+        use_subordinate = keyed_args.get('use_subordinate', False)
 
-        if use_slave:
+        if use_subordinate:
             reader_mode = get_context_manager(context).async
         else:
             reader_mode = get_context_manager(context).reader
@@ -6505,7 +6505,7 @@ def archive_deleted_rows(max_rows=None):
     """
     table_to_rows_archived = {}
     total_rows_archived = 0
-    meta = MetaData(get_engine(use_slave=True))
+    meta = MetaData(get_engine(use_subordinate=True))
     meta.reflect()
     # Reverse sort the tables so we get the leaf nodes first for processing.
     for table in reversed(meta.sorted_tables):

--- a/nova/network/ldapdns.py
+++ b/nova/network/ldapdns.py
@@ -116,7 +116,7 @@ class DomainEntry(DNSEntry):
         date = time.strftime('%Y%m%d%H%M%S')
         soa = '%s %s %s %d %d %d %d' % (
                  CONF.ldap_dns_servers[0],
-                 CONF.ldap_dns_soa_hostmaster,
+                 CONF.ldap_dns_soa_hostmain,
                  date,
                  CONF.ldap_dns_soa_refresh,
                  CONF.ldap_dns_soa_retry,

--- a/nova/network/linux_net.py
+++ b/nova/network/linux_net.py
@@ -1556,7 +1556,7 @@ class LinuxBridgeInterfaceDriver(LinuxNetInterfaceDriver):
             out, err = _execute('brctl', 'addif', bridge, interface,
                                 check_exit_code=False, run_as_root=True)
             if (err and err != "device %s is already a member of a bridge; "
-                     "can't enslave it to bridge %s.\n" % (interface, bridge)):
+                     "can't ensubordinate it to bridge %s.\n" % (interface, bridge)):
                 msg = _('Failed to add interface: %s') % err
                 raise exception.NovaException(msg)
 

--- a/nova/objects/bandwidth_usage.py
+++ b/nova/objects/bandwidth_usage.py
@@ -18,7 +18,7 @@ from nova.objects import fields
 @base.NovaObjectRegistry.register
 class BandwidthUsage(base.NovaPersistentObject, base.NovaObject):
     # Version 1.0: Initial version
-    # Version 1.1: Add use_slave to get_by_instance_uuid_and_mac
+    # Version 1.1: Add use_subordinate to get_by_instance_uuid_and_mac
     # Version 1.2: Add update_cells to create
     VERSION = '1.2'
 
@@ -46,17 +46,17 @@ class BandwidthUsage(base.NovaPersistentObject, base.NovaObject):
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+    def _db_bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
         return db.bw_usage_get(context, uuid=uuid, start_period=start_period,
                                mac=mac)
 
     @base.serialize_args
     @base.remotable_classmethod
     def get_by_instance_uuid_and_mac(cls, context, instance_uuid, mac,
-                                     start_period=None, use_slave=False):
+                                     start_period=None, use_subordinate=False):
         db_bw_usage = cls._db_bw_usage_get(context, uuid=instance_uuid,
                                       start_period=start_period, mac=mac,
-                                      use_slave=use_slave)
+                                      use_subordinate=use_subordinate)
         if db_bw_usage:
             return cls._from_db_object(context, cls(), db_bw_usage)
 
@@ -76,7 +76,7 @@ class BandwidthUsage(base.NovaPersistentObject, base.NovaObject):
 @base.NovaObjectRegistry.register
 class BandwidthUsageList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
-    # Version 1.1: Add use_slave to get_by_uuids
+    # Version 1.1: Add use_subordinate to get_by_uuids
     # Version 1.2: BandwidthUsage <= version 1.2
     VERSION = '1.2'
     fields = {
@@ -86,14 +86,14 @@ class BandwidthUsageList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_bw_usage_get_by_uuids(context, uuids, start_period,
-                                  use_slave=False):
+                                  use_subordinate=False):
         return db.bw_usage_get_by_uuids(context, uuids=uuids,
                                         start_period=start_period)
 
     @base.serialize_args
     @base.remotable_classmethod
-    def get_by_uuids(cls, context, uuids, start_period=None, use_slave=False):
+    def get_by_uuids(cls, context, uuids, start_period=None, use_subordinate=False):
         db_bw_usages = cls._db_bw_usage_get_by_uuids(context, uuids=uuids,
                                                 start_period=start_period,
-                                                use_slave=use_slave)
+                                                use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(), BandwidthUsage, db_bw_usages)

--- a/nova/objects/block_device.py
+++ b/nova/objects/block_device.py
@@ -299,7 +299,7 @@ class BlockDeviceMapping(base.NovaPersistentObject, base.NovaObject,
 class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     # Version 1.1: BlockDeviceMapping <= version 1.1
-    # Version 1.2: Added use_slave to get_by_instance_uuid
+    # Version 1.2: Added use_subordinate to get_by_instance_uuid
     # Version 1.3: BlockDeviceMapping <= version 1.2
     # Version 1.4: BlockDeviceMapping <= version 1.3
     # Version 1.5: BlockDeviceMapping <= version 1.4
@@ -337,28 +337,28 @@ class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_block_device_mapping_get_all_by_instance_uuids(
-            context, instance_uuids, use_slave=False):
+            context, instance_uuids, use_subordinate=False):
         return db.block_device_mapping_get_all_by_instance_uuids(
                 context, instance_uuids)
 
     @base.remotable_classmethod
-    def get_by_instance_uuids(cls, context, instance_uuids, use_slave=False):
+    def get_by_instance_uuids(cls, context, instance_uuids, use_subordinate=False):
         db_bdms = cls._db_block_device_mapping_get_all_by_instance_uuids(
-            context, instance_uuids, use_slave=use_slave)
+            context, instance_uuids, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), objects.BlockDeviceMapping, db_bdms or [])
 
     @staticmethod
     @db.select_db_reader_mode
     def _db_block_device_mapping_get_all_by_instance(
-            context, instance_uuid, use_slave=False):
+            context, instance_uuid, use_subordinate=False):
         return db.block_device_mapping_get_all_by_instance(
             context, instance_uuid)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_bdms = cls._db_block_device_mapping_get_all_by_instance(
-            context, instance_uuid, use_slave=use_slave)
+            context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), objects.BlockDeviceMapping, db_bdms or [])
 

--- a/nova/objects/compute_node.py
+++ b/nova/objects/compute_node.py
@@ -267,8 +267,8 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
     # TODO(pkholkin): Remove this method in the next major version bump
     @base.remotable_classmethod
     def get_first_node_by_host_for_old_compat(cls, context, host,
-                                              use_slave=False):
-        computes = ComputeNodeList.get_all_by_host(context, host, use_slave)
+                                              use_subordinate=False):
+        computes = ComputeNodeList.get_all_by_host(context, host, use_subordinate)
         # FIXME(sbauza): Some hypervisors (VMware, Ironic) can return multiple
         # nodes per host, we should return all the nodes and modify the callers
         # instead.
@@ -366,7 +366,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # Version 1.2 Add get_by_service()
     # Version 1.3 ComputeNode version 1.4
     # Version 1.4 ComputeNode version 1.5
-    # Version 1.5 Add use_slave to get_by_service
+    # Version 1.5 Add use_subordinate to get_by_service
     # Version 1.6 ComputeNode version 1.6
     # Version 1.7 ComputeNode version 1.7
     # Version 1.8 ComputeNode version 1.8 + add get_all_by_host()
@@ -415,7 +415,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # NOTE(hanlind): This is deprecated and should be removed on the next
     # major version bump
     @base.remotable_classmethod
-    def _get_by_service(cls, context, service_id, use_slave=False):
+    def _get_by_service(cls, context, service_id, use_subordinate=False):
         try:
             db_computes = db.compute_nodes_get_by_service_id(
                 context, service_id)
@@ -428,13 +428,13 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_compute_node_get_all_by_host(context, host, use_slave=False):
+    def _db_compute_node_get_all_by_host(context, host, use_subordinate=False):
         return db.compute_node_get_all_by_host(context, host)
 
     @base.remotable_classmethod
-    def get_all_by_host(cls, context, host, use_slave=False):
+    def get_all_by_host(cls, context, host, use_subordinate=False):
         db_computes = cls._db_compute_node_get_all_by_host(context, host,
-                                                      use_slave=use_slave)
+                                                      use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context), objects.ComputeNode,
                                   db_computes)
 

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -454,17 +454,17 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
     @staticmethod
     @db.select_db_reader_mode
     def _db_instance_get_by_uuid(context, uuid, columns_to_join,
-                                 use_slave=False):
+                                 use_subordinate=False):
         return db.instance_get_by_uuid(context, uuid,
                                        columns_to_join=columns_to_join)
 
     @base.remotable_classmethod
-    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_slave=False):
+    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_subordinate=False):
         if expected_attrs is None:
             expected_attrs = ['info_cache', 'security_groups']
         columns_to_join = _expected_cols(expected_attrs)
         db_inst = cls._db_instance_get_by_uuid(context, uuid, columns_to_join,
-                                               use_slave=use_slave)
+                                               use_subordinate=use_subordinate)
         return cls._from_db_object(context, cls(), db_inst,
                                    expected_attrs)
 
@@ -812,12 +812,12 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         self.obj_reset_changes()
 
     @base.remotable
-    def refresh(self, use_slave=False):
+    def refresh(self, use_subordinate=False):
         extra = [field for field in INSTANCE_OPTIONAL_ATTRS
                        if self.obj_attr_is_set(field)]
         current = self.__class__.get_by_uuid(self._context, uuid=self.uuid,
                                              expected_attrs=extra,
-                                             use_slave=use_slave)
+                                             use_subordinate=use_subordinate)
         # NOTE(danms): We orphan the instance copy so we do not unexpectedly
         # trigger a lazy-load (which would mean we failed to calculate the
         # expected_attrs properly)
@@ -1220,7 +1220,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @db.select_db_reader_mode
     def _get_by_filters_impl(cls, context, filters,
                        sort_key='created_at', sort_dir='desc', limit=None,
-                       marker=None, expected_attrs=None, use_slave=False,
+                       marker=None, expected_attrs=None, use_subordinate=False,
                        sort_keys=None, sort_dirs=None):
         if sort_keys or sort_dirs:
             db_inst_list = db.instance_get_all_by_filters_sort(
@@ -1237,25 +1237,25 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def get_by_filters(cls, context, filters,
                        sort_key='created_at', sort_dir='desc', limit=None,
-                       marker=None, expected_attrs=None, use_slave=False,
+                       marker=None, expected_attrs=None, use_subordinate=False,
                        sort_keys=None, sort_dirs=None):
         return cls._get_by_filters_impl(
             context, filters, sort_key=sort_key, sort_dir=sort_dir,
             limit=limit, marker=marker, expected_attrs=expected_attrs,
-            use_slave=use_slave, sort_keys=sort_keys, sort_dirs=sort_dirs)
+            use_subordinate=use_subordinate, sort_keys=sort_keys, sort_dirs=sort_dirs)
 
     @staticmethod
     @db.select_db_reader_mode
     def _db_instance_get_all_by_host(context, host, columns_to_join,
-                                     use_slave=False):
+                                     use_subordinate=False):
         return db.instance_get_all_by_host(context, host,
                                            columns_to_join=columns_to_join)
 
     @base.remotable_classmethod
-    def get_by_host(cls, context, host, expected_attrs=None, use_slave=False):
+    def get_by_host(cls, context, host, expected_attrs=None, use_subordinate=False):
         db_inst_list = cls._db_instance_get_all_by_host(
             context, host, columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
@@ -1295,7 +1295,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @db.select_db_reader_mode
     def _db_instance_get_active_by_window_joined(
             context, begin, end, project_id, host, columns_to_join,
-            use_slave=False, limit=None, marker=None):
+            use_subordinate=False, limit=None, marker=None):
         return db.instance_get_active_by_window_joined(
             context, begin, end, project_id, host,
             columns_to_join=columns_to_join, limit=limit, marker=marker)
@@ -1303,7 +1303,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def _get_active_by_window_joined(cls, context, begin, end=None,
                                     project_id=None, host=None,
-                                    expected_attrs=None, use_slave=False,
+                                    expected_attrs=None, use_subordinate=False,
                                     limit=None, marker=None):
         # NOTE(mriedem): We need to convert the begin/end timestamp strings
         # to timezone-aware datetime objects for the DB API call.
@@ -1312,14 +1312,14 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         db_inst_list = cls._db_instance_get_active_by_window_joined(
             context, begin, end, project_id, host,
             columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave, limit=limit, marker=marker)
+            use_subordinate=use_subordinate, limit=limit, marker=marker)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
     @classmethod
     def get_active_by_window_joined(cls, context, begin, end=None,
                                     project_id=None, host=None,
-                                    expected_attrs=None, use_slave=False,
+                                    expected_attrs=None, use_subordinate=False,
                                     limit=None, marker=None):
         """Get instances and joins active during a certain time window.
 
@@ -1330,7 +1330,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         :param:host: used to filter instances on a given compute host
         :param:expected_attrs: list of related fields that can be joined
         in the database layer when querying for instances
-        :param use_slave if True, ship this query off to a DB slave
+        :param use_subordinate if True, ship this query off to a DB subordinate
         :param limit: maximum number of instances to return per page
         :param marker: last instance uuid from the previous page
         :returns: InstanceList
@@ -1343,7 +1343,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         return cls._get_active_by_window_joined(context, begin, end,
                                                 project_id, host,
                                                 expected_attrs,
-                                                use_slave=use_slave,
+                                                use_subordinate=use_subordinate,
                                                 limit=limit, marker=marker)
 
     @base.remotable_classmethod

--- a/nova/objects/migration.py
+++ b/nova/objects/migration.py
@@ -156,7 +156,7 @@ class Migration(base.NovaPersistentObject, base.NovaObject,
 class MigrationList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     #              Migration <= 1.1
-    # Version 1.1: Added use_slave to get_unconfirmed_by_dest_compute
+    # Version 1.1: Added use_subordinate to get_unconfirmed_by_dest_compute
     # Version 1.2: Migration version 1.2
     # Version 1.3: Added a new function to get in progress migrations
     #              for an instance.
@@ -169,15 +169,15 @@ class MigrationList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=False):
+            context, confirm_window, dest_compute, use_subordinate=False):
         return db.migration_get_unconfirmed_by_dest_compute(
             context, confirm_window, dest_compute)
 
     @base.remotable_classmethod
     def get_unconfirmed_by_dest_compute(cls, context, confirm_window,
-                                        dest_compute, use_slave=False):
+                                        dest_compute, use_subordinate=False):
         db_migrations = cls._db_migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=use_slave)
+            context, confirm_window, dest_compute, use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context), objects.Migration,
                                   db_migrations)
 

--- a/nova/objects/service.py
+++ b/nova/objects/service.py
@@ -123,7 +123,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
     # Version 1.1: Added compute_node nested object
     # Version 1.2: String attributes updated to support unicode
     # Version 1.3: ComputeNode version 1.5
-    # Version 1.4: Added use_slave to get_by_compute_host
+    # Version 1.4: Added use_subordinate to get_by_compute_host
     # Version 1.5: ComputeNode version 1.6
     # Version 1.6: ComputeNode version 1.7
     # Version 1.7: ComputeNode version 1.8
@@ -299,13 +299,13 @@ class Service(base.NovaPersistentObject, base.NovaObject,
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_service_get_by_compute_host(context, host, use_slave=False):
+    def _db_service_get_by_compute_host(context, host, use_subordinate=False):
         return db.service_get_by_compute_host(context, host)
 
     @base.remotable_classmethod
-    def get_by_compute_host(cls, context, host, use_slave=False):
+    def get_by_compute_host(cls, context, host, use_subordinate=False):
         db_service = cls._db_service_get_by_compute_host(context, host,
-                                                         use_slave=use_slave)
+                                                         use_subordinate=use_subordinate)
         return cls._from_db_object(context, cls(), db_service)
 
     # NOTE(ndipanov): This is deprecated and should be removed on the next
@@ -395,11 +395,11 @@ class Service(base.NovaPersistentObject, base.NovaObject,
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_service_get_minimum_version(context, binaries, use_slave=False):
+    def _db_service_get_minimum_version(context, binaries, use_subordinate=False):
         return db.service_get_minimum_version(context, binaries)
 
     @base.remotable_classmethod
-    def get_minimum_version_multi(cls, context, binaries, use_slave=False):
+    def get_minimum_version_multi(cls, context, binaries, use_subordinate=False):
         if not all(binary.startswith('nova-') for binary in binaries):
             LOG.warning('get_minimum_version called with likely-incorrect '
                         'binaries `%s\'', ','.join(binaries))
@@ -410,7 +410,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
               any(binary not in cls._MIN_VERSION_CACHE
                   for binary in binaries)):
             min_versions = cls._db_service_get_minimum_version(
-                context, binaries, use_slave=use_slave)
+                context, binaries, use_subordinate=use_subordinate)
             if min_versions:
                 min_versions = {binary: version or 0
                                 for binary, version in
@@ -431,9 +431,9 @@ class Service(base.NovaPersistentObject, base.NovaObject,
         return version
 
     @base.remotable_classmethod
-    def get_minimum_version(cls, context, binary, use_slave=False):
+    def get_minimum_version(cls, context, binary, use_subordinate=False):
         return cls.get_minimum_version_multi(context, [binary],
-                                             use_slave=use_slave)
+                                             use_subordinate=use_subordinate)
 
 
 def get_minimum_version_all_cells(context, binaries):

--- a/nova/objects/virtual_interface.py
+++ b/nova/objects/virtual_interface.py
@@ -133,12 +133,12 @@ class VirtualInterfaceList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_virtual_interface_get_by_instance(context, instance_uuid,
-                                              use_slave=False):
+                                              use_subordinate=False):
         return db.virtual_interface_get_by_instance(context, instance_uuid)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_vifs = cls._db_virtual_interface_get_by_instance(
-            context, instance_uuid, use_slave=use_slave)
+            context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context),
                                   objects.VirtualInterface, db_vifs)

--- a/nova/pci/manager.py
+++ b/nova/pci/manager.py
@@ -40,7 +40,7 @@ class PciDevTracker(object):
     devices to/from instances, and to update the available pci passthrough
     devices information from hypervisor periodically.
 
-    `pci_devs` attribute of this class is the in-memory "master copy" of all
+    `pci_devs` attribute of this class is the in-memory "main copy" of all
     devices on each compute host, and all data changes that happen when
     claiming/allocating/freeing
     devices HAVE TO be made against instances contained in `pci_devs` list,

--- a/nova/tests/functional/api_sample_tests/test_volumes.py
+++ b/nova/tests/functional/api_sample_tests/test_volumes.py
@@ -199,7 +199,7 @@ class VolumeAttachmentsSample(test_servers.ServersSampleBase):
     def _stub_db_bdms_get_all_by_instance(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/nova/tests/unit/api/openstack/compute/test_disk_config.py
+++ b/nova/tests/unit/api/openstack/compute/test_disk_config.py
@@ -66,7 +66,7 @@ class DiskConfigTestCaseV21(test.TestCase):
         self.stub_out('nova.db.instance_get', fake_instance_get)
 
         def fake_instance_get_by_uuid(context, uuid,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             for instance in FAKE_INSTANCES:
                 if uuid == instance['uuid']:
                     return instance

--- a/nova/tests/unit/api/openstack/compute/test_security_groups.py
+++ b/nova/tests/unit/api/openstack/compute/test_security_groups.py
@@ -87,7 +87,7 @@ def security_group_rule_db(rule, id=None):
 
 
 def return_server(context, server_id,
-                  columns_to_join=None, use_slave=False):
+                  columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'power_state': 0x01,
@@ -98,7 +98,7 @@ def return_server(context, server_id,
 
 def return_server_by_uuid(context, server_uuid,
                           columns_to_join=None,
-                          use_slave=False):
+                          use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'power_state': 0x01,
@@ -437,7 +437,7 @@ class TestSecurityGroupsV21(test.TestCase):
         expected = {'security_groups': groups}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
 
@@ -462,7 +462,7 @@ class TestSecurityGroupsV21(test.TestCase):
         expected = {'security_groups': []}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
         mock_db_get_ins.side_effect = return_instance

--- a/nova/tests/unit/api/openstack/compute/test_server_actions.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_actions.py
@@ -475,7 +475,7 @@ class ServerActionsControllerTestV21(test.TestCase):
 
     def test_rebuild_server_not_found(self):
         def server_not_found(self, instance_id,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
             raise exception.InstanceNotFound(instance_id=instance_id)
         self.stub_out('nova.db.instance_get_by_uuid', server_not_found)
 
@@ -945,7 +945,7 @@ class ServerActionsControllerTestV21(test.TestCase):
                     delete_on_termination=False)]
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',
@@ -1051,7 +1051,7 @@ class ServerActionsControllerTestV21(test.TestCase):
         image_service = glance.get_default_image_service()
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',

--- a/nova/tests/unit/api/openstack/compute/test_server_metadata.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_metadata.py
@@ -91,7 +91,7 @@ def return_server(context, server_id, columns_to_join=None):
 
 
 def return_server_by_uuid(context, server_uuid,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',
@@ -103,7 +103,7 @@ def return_server_by_uuid(context, server_uuid,
 
 
 def return_server_nonexistent(context, server_id,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=server_id)
 
 
@@ -722,7 +722,7 @@ class BadStateServerMetaDataTestV21(test.TestCase):
                'vm_state': vm_states.BUILDING})
 
     def _return_server_in_build_by_uuid(self, context, server_uuid,
-                                        columns_to_join=None, use_slave=False):
+                                        columns_to_join=None, use_subordinate=False):
         return fake_instance.fake_db_instance(
             **{'id': 1,
                'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',

--- a/nova/tests/unit/api/openstack/compute/test_serversV21.py
+++ b/nova/tests/unit/api/openstack/compute/test_serversV21.py
@@ -116,7 +116,7 @@ def fake_start_stop_invalid_state(self, context, instance):
 
 
 def fake_instance_get_by_uuid_not_found(context, uuid,
-                                        columns_to_join, use_slave=False):
+                                        columns_to_join, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=uuid)
 
 

--- a/nova/tests/unit/api/openstack/compute/test_simple_tenant_usage.py
+++ b/nova/tests/unit/api/openstack/compute/test_simple_tenant_usage.py
@@ -93,7 +93,7 @@ def _fake_instance(start, end, instance_id, tenant_id,
 @classmethod
 def fake_get_active_by_window_joined(cls, context, begin, end=None,
                                      project_id=None, host=None,
-                                     expected_attrs=None, use_slave=False,
+                                     expected_attrs=None, use_subordinate=False,
                                      limit=None, marker=None):
     return objects.InstanceList(objects=[
         _fake_instance(START, STOP, x,
@@ -186,12 +186,12 @@ class SimpleTenantUsageTestV21(test.TestCase):
 
         def fake_get_active_by_window_joined(context, begin, end=None,
                                     project_id=None, host=None,
-                                    expected_attrs=None, use_slave=False,
+                                    expected_attrs=None, use_subordinate=False,
                                     limit=None, marker=None):
             self.assertEqual(['flavor'], expected_attrs)
             return orig_get_active_by_window_joined(context, begin, end,
                                                     project_id, host,
-                                                    expected_attrs, use_slave)
+                                                    expected_attrs, use_subordinate)
 
         with mock.patch.object(objects.InstanceList,
                                'get_active_by_window_joined',

--- a/nova/tests/unit/api/openstack/fakes.py
+++ b/nova/tests/unit/api/openstack/fakes.py
@@ -344,7 +344,7 @@ def get_fake_uuid(token=0):
 
 
 def fake_instance_get(**kwargs):
-    def _return_server(context, uuid, columns_to_join=None, use_slave=False):
+    def _return_server(context, uuid, columns_to_join=None, use_subordinate=False):
         if 'project_id' not in kwargs:
             kwargs['project_id'] = 'fake'
         return stub_instance(1, **kwargs)
@@ -375,8 +375,8 @@ def fake_instance_get_all_by_filters(num_servers=5, **kwargs):
         if 'columns_to_join' in kwargs:
             kwargs.pop('columns_to_join')
 
-        if 'use_slave' in kwargs:
-            kwargs.pop('use_slave')
+        if 'use_subordinate' in kwargs:
+            kwargs.pop('use_subordinate')
 
         if 'sort_keys' in kwargs:
             kwargs.pop('sort_keys')
@@ -681,7 +681,7 @@ def stub_snapshot_get_all(self, context):
 
 
 def stub_bdm_get_all_by_instance_uuids(context, instance_uuids,
-                                       use_slave=False):
+                                       use_subordinate=False):
     i = 1
     result = []
     for instance_uuid in instance_uuids:

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -693,7 +693,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         mock_get_counter.assert_called_once_with([])
         mock_last.assert_called_once_with()
         mock_get_host.assert_called_once_with(ctxt, 'fake-mini',
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch.object(objects.InstanceList, 'get_by_host')
     @mock.patch.object(objects.BlockDeviceMappingList,
@@ -712,10 +712,10 @@ class ComputeVolumeTestCase(BaseTestCase):
         got_host_bdms = self.compute._get_host_volume_bdms('fake-context')
         mock_get_by_host.assert_called_once_with('fake-context',
                                                  self.compute.host,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         mock_get_by_inst.assert_called_once_with('fake-context',
                                                  uuids.volume_instance,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         self.assertEqual(expected_host_bdms, got_host_bdms)
 
     @mock.patch.object(utils, 'last_completed_audit_period')
@@ -741,7 +741,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.flags(volume_usage_poll_interval=10)
         self.compute._poll_volume_usage(ctxt)
 
-        mock_get_bdms.assert_called_once_with(ctxt, use_slave=True)
+        mock_get_bdms.assert_called_once_with(ctxt, use_subordinate=True)
 
     @mock.patch.object(compute_manager.ComputeManager, '_get_host_volume_bdms')
     @mock.patch.object(compute_manager.ComputeManager,
@@ -757,7 +757,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.flags(volume_usage_poll_interval=10)
         self.compute._poll_volume_usage(ctxt)
 
-        mock_get_bdms.assert_called_once_with(ctxt, use_slave=True)
+        mock_get_bdms.assert_called_once_with(ctxt, use_subordinate=True)
         mock_update.assert_called_once_with(ctxt, [3, 4])
 
     @mock.patch('nova.context.RequestContext.elevated')
@@ -866,7 +866,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         mock_get.assert_called_once_with(self.context, uuids.volume_id,
                                          instance.uuid)
         mock_stats.assert_called_once_with(instance, 'vdb')
-        mock_get_bdms.assert_called_once_with(self.context, use_slave=True)
+        mock_get_bdms.assert_called_once_with(self.context, use_subordinate=True)
         mock_get_all(self.context, host_volume_bdms)
         mock_exists.assert_called_once_with(mock.ANY)
 
@@ -6609,8 +6609,8 @@ class ComputeTestCase(BaseTestCase,
             mock.call(ctxt, inst2, bdms, notify=False)])
         mock_cleanup.assert_called_once_with(ctxt, inst2['uuid'], bdms)
         mock_get_uuid.assert_has_calls([
-            mock.call(ctxt, inst1.uuid, use_slave=True),
-            mock.call(ctxt, inst2.uuid, use_slave=True)])
+            mock.call(ctxt, inst1.uuid, use_subordinate=True),
+            mock.call(ctxt, inst2.uuid, use_subordinate=True)])
         mock_get_inst.assert_called_once_with(ctxt,
                                               {'deleted': True,
                                                'soft_deleted': False})
@@ -6714,13 +6714,13 @@ class ComputeTestCase(BaseTestCase,
                 'get_nw_info': 0, 'expected_instance': None}
 
         def fake_instance_get_all_by_host(context, host,
-                                          columns_to_join, use_slave=False):
+                                          columns_to_join, use_subordinate=False):
             call_info['get_all_by_host'] += 1
             self.assertEqual([], columns_to_join)
             return instances[:]
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                                      columns_to_join, use_slave=False):
+                                      columns_to_join, use_subordinate=False):
             if instance_uuid not in instance_map:
                 raise exception.InstanceNotFound(instance_id=instance_uuid)
             call_info['get_by_uuid'] += 1
@@ -6731,7 +6731,7 @@ class ComputeTestCase(BaseTestCase,
 
         # NOTE(comstud): Override the stub in setUp()
         def fake_get_instance_nw_info(cls, context, instance,
-                                      use_slave=False):
+                                      use_subordinate=False):
             # Note that this exception gets caught in compute/manager
             # and is ignored.  However, the below increment of
             # 'get_nw_info' won't happen, and you'll get an assert
@@ -6834,7 +6834,7 @@ class ComputeTestCase(BaseTestCase,
 
         def fake_instance_get_all_by_filters(context, filters,
                                              expected_attrs=None,
-                                             use_slave=False):
+                                             use_subordinate=False):
             self.assertEqual(["system_metadata"], expected_attrs)
             return instances
 
@@ -6884,7 +6884,7 @@ class ComputeTestCase(BaseTestCase,
                        task_states.REBOOTING, task_states.REBOOT_STARTED,
                        task_states.REBOOT_PENDING]}
         get.assert_called_once_with(ctxt, filters,
-                                    expected_attrs=[], use_slave=True)
+                                    expected_attrs=[], use_subordinate=True)
 
     def test_poll_unconfirmed_resizes(self):
         instances = [
@@ -6936,7 +6936,7 @@ class ComputeTestCase(BaseTestCase,
             migrations.append(fake_mig)
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                columns_to_join=None, use_slave=False):
+                columns_to_join=None, use_subordinate=False):
             self.assertIn('metadata', columns_to_join)
             self.assertIn('system_metadata', columns_to_join)
             # raise InstanceNotFound exception for non-existing instance
@@ -6948,7 +6948,7 @@ class ComputeTestCase(BaseTestCase,
                     return instance
 
         def fake_migration_get_unconfirmed_by_dest_compute(context,
-                resize_confirm_window, dest_compute, use_slave=False):
+                resize_confirm_window, dest_compute, use_subordinate=False):
             self.assertEqual(dest_compute, CONF.host)
             return migrations
 
@@ -7438,7 +7438,7 @@ class ComputeTestCase(BaseTestCase,
 
         mock_get_filter.assert_called_once_with(ctxt, mock.ANY,
                 expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-                use_slave=True)
+                use_subordinate=True)
         mock_delete_old.assert_has_calls([mock.call(instance1, 3600),
                                           mock.call(instance2, 3600)])
         mock_get_uuid.assert_has_calls([mock.call(ctxt, instance1.uuid),
@@ -7468,9 +7468,9 @@ class ComputeTestCase(BaseTestCase,
         mock_get.assert_has_calls([mock.call(mock.ANY), mock.call(mock.ANY),
                                    mock.call(mock.ANY)])
         mock_sync.assert_has_calls([
-            mock.call(ctxt, mock.ANY, power_state.NOSTATE, use_slave=True),
-            mock.call(ctxt, mock.ANY, power_state.RUNNING, use_slave=True),
-            mock.call(ctxt, mock.ANY, power_state.SHUTDOWN, use_slave=True)])
+            mock.call(ctxt, mock.ANY, power_state.NOSTATE, use_subordinate=True),
+            mock.call(ctxt, mock.ANY, power_state.RUNNING, use_subordinate=True),
+            mock.call(ctxt, mock.ANY, power_state.SHUTDOWN, use_subordinate=True)])
 
     @mock.patch.object(compute_manager.ComputeManager, '_get_power_state')
     @mock.patch.object(compute_manager.ComputeManager,
@@ -11603,7 +11603,7 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="host",
-                aggregate=jsonutils.to_primitive(self.aggr), slave_info=None)
+                aggregate=jsonutils.to_primitive(self.aggr), subordinate_info=None)
         self.assertTrue(fake_driver_add_to_aggregate.called)
 
     def test_remove_aggregate_host(self):
@@ -11617,37 +11617,37 @@ class ComputeAggrTestCase(BaseTestCase):
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="host",
-                slave_info=None)
+                subordinate_info=None)
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(cls, context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stub_out("nova.virt.fake.FakeDriver.add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="the_host",
-                slave_info="SLAVE_INFO",
+                subordinate_info="SLAVE_INFO",
                 aggregate=jsonutils.to_primitive(self.aggr))
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(cls, context, aggregate, host,
                                          **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stub_out("nova.virt.fake.FakeDriver.remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="the_host",
-                slave_info="SLAVE_INFO")
+                subordinate_info="SLAVE_INFO")
 
 
 class DisabledInstanceTypesTestCase(BaseTestCase):

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -229,7 +229,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         get_db_nodes.return_value = db_nodes
         get_avail_nodes.return_value = avail_nodes
         self.compute.update_available_resource(self.context)
-        get_db_nodes.assert_called_once_with(self.context, use_slave=True,
+        get_db_nodes.assert_called_once_with(self.context, use_subordinate=True,
                                              startup=False)
         update_mock.has_calls(
             [mock.call(self.context, node) for node in avail_nodes_l]
@@ -266,7 +266,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         self.assertEqual([], self.compute._get_compute_nodes_in_db(
             self.context, startup=True))
         get_all_by_host.assert_called_once_with(
-            self.context, self.compute.host, use_slave=False)
+            self.context, self.compute.host, use_subordinate=False)
         self.assertTrue(mock_log.warning.called)
         self.assertFalse(mock_log.error.called)
 
@@ -1435,7 +1435,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                          [x['uuid'] for x in result])
         expected_filters = {'uuid': driver_uuids}
         mock_instance_list.assert_called_with(self.context, expected_filters,
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch('nova.objects.InstanceList.get_by_filters')
     def test_get_instances_on_driver_empty(self, mock_instance_list):
@@ -1490,7 +1490,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                          [x['uuid'] for x in result])
         expected_filters = {'host': self.compute.host}
         mock_instance_list.assert_called_with(self.context, expected_filters,
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     def test_instance_usage_audit(self):
         instances = [objects.Instance(uuid=uuids.instance)]
@@ -1531,7 +1531,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             self.compute._sync_power_states(mock.sentinel.context)
             mock_get.assert_called_with(mock.sentinel.context,
                                         self.compute.host, expected_attrs=[],
-                                        use_slave=True)
+                                        use_subordinate=True)
             mock_spawn.assert_called_once_with(mock.ANY, instance)
 
     def _get_sync_instance(self, power_state, vm_state, task_state=None,
@@ -1551,7 +1551,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                                            vm_states.ACTIVE)
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.RUNNING)
-        mock_refresh.assert_called_once_with(use_slave=False)
+        mock_refresh.assert_called_once_with(use_subordinate=False)
 
     @mock.patch.object(objects.Instance, 'refresh')
     @mock.patch.object(objects.Instance, 'save')
@@ -1562,7 +1562,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.SHUTDOWN)
         self.assertEqual(instance.power_state, power_state.SHUTDOWN)
-        mock_refresh.assert_called_once_with(use_slave=False)
+        mock_refresh.assert_called_once_with(use_subordinate=False)
         self.assertTrue(mock_save.called)
 
     def _test_sync_to_stop(self, power_state, vm_state, driver_power_state,
@@ -1586,7 +1586,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                     mock_force.assert_called_once_with(self.context, instance)
                 else:
                     mock_stop.assert_called_once_with(self.context, instance)
-            mock_refresh.assert_called_once_with(use_slave=False)
+            mock_refresh.assert_called_once_with(use_subordinate=False)
             self.assertTrue(mock_save.called)
 
     def test_sync_instance_power_state_to_stop(self):
@@ -1643,7 +1643,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             mock_sync_power_state.assert_called_once_with(self.context,
                                                           db_instance,
                                                           power_state.NOSTATE,
-                                                          use_slave=True)
+                                                          use_subordinate=True)
 
     @mock.patch.object(virt_driver.ComputeDriver, 'delete_instance_files')
     @mock.patch.object(objects.InstanceList, 'get_by_filters')
@@ -1663,13 +1663,13 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             def save(self):
                 pass
 
-        def _fake_get(ctx, filter, expected_attrs, use_slave):
+        def _fake_get(ctx, filter, expected_attrs, use_subordinate):
             mock_get.assert_called_once_with(
                 {'read_deleted': 'yes'},
                 {'deleted': True, 'soft_deleted': False, 'host': 'fake-mini',
                  'cleaned': False},
                 expected_attrs=['system_metadata'],
-                use_slave=True)
+                use_subordinate=True)
             return [a, b, c]
 
         a = FakeInstance('123', 'apple', {'clean_attempts': '100'})
@@ -3692,7 +3692,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             self.compute._poll_bandwidth_usage(self.context)
             get_by_uuid_mac.assert_called_once_with(self.context,
                     uuids.instance, 'fake-mac',
-                    start_period=0, use_slave=True)
+                    start_period=0, use_subordinate=True)
             # NOTE(sdague): bw_usage_update happens at some time in
             # the future, so what last_refreshed is irrelevant.
             bw_usage_update.assert_called_once_with(self.context,
@@ -3765,7 +3765,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         self.compute._sync_scheduler_instance_info(self.context)
         mock_get_by_host.assert_called_once_with(
                 fake_elevated, self.compute.host, expected_attrs=[],
-                use_slave=True)
+                use_subordinate=True)
         mock_sync.assert_called_once_with(fake_elevated, self.compute.host,
                                           exp_uuids)
 

--- a/nova/tests/unit/compute/test_compute_xen.py
+++ b/nova/tests/unit/compute/test_compute_xen.py
@@ -63,10 +63,10 @@ class ComputeXenTestCase(stubs.XenAPITestBaseNoDB):
             self.compute._sync_power_states(ctxt)
 
             mock_instance_list_get_by_host.assert_called_once_with(
-               ctxt, self.compute.host, expected_attrs=[], use_slave=True)
+               ctxt, self.compute.host, expected_attrs=[], use_subordinate=True)
             mock_compute_get_num_instances.assert_called_once_with()
             mock_compute_sync_powerstate.assert_called_once_with(
-               ctxt, instance, power_state.NOSTATE, use_slave=True)
+               ctxt, instance, power_state.NOSTATE, use_subordinate=True)
             mock_vm_utils_lookup.assert_called_once_with(
                self.compute.driver._session, instance['name'],
                False)

--- a/nova/tests/unit/compute/test_rpcapi.py
+++ b/nova/tests/unit/compute/test_rpcapi.py
@@ -175,7 +175,7 @@ class ComputeRpcAPITestCase(test.NoDBTestCase):
     def test_add_aggregate_host(self):
         self._test_compute_api('add_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
     def test_add_fixed_ip_to_instance(self):
         self._test_compute_api('add_fixed_ip_to_instance', 'cast',
@@ -590,7 +590,7 @@ class ComputeRpcAPITestCase(test.NoDBTestCase):
     def test_remove_aggregate_host(self):
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
     def test_remove_fixed_ip_from_instance(self):
         self._test_compute_api('remove_fixed_ip_from_instance', 'cast',

--- a/nova/tests/unit/db/test_db_api.py
+++ b/nova/tests/unit/db/test_db_api.py
@@ -219,7 +219,7 @@ class DecoratorTestCase(test.TestCase):
     def test_select_db_reader_mode_select_sync(self, mock_clone, mock_using):
 
         @db.select_db_reader_mode
-        def func(self, context, value, use_slave=False):
+        def func(self, context, value, use_subordinate=False):
             pass
 
         mock_clone.return_value = enginefacade._TransactionContextManager(
@@ -236,21 +236,21 @@ class DecoratorTestCase(test.TestCase):
     def test_select_db_reader_mode_select_async(self, mock_clone, mock_using):
 
         @db.select_db_reader_mode
-        def func(self, context, value, use_slave=False):
+        def func(self, context, value, use_subordinate=False):
             pass
 
         mock_clone.return_value = enginefacade._TransactionContextManager(
             mode=enginefacade._ASYNC_READER)
         ctxt = context.get_admin_context()
         value = 'some_value'
-        func(self, ctxt, value, use_slave=True)
+        func(self, ctxt, value, use_subordinate=True)
 
         mock_clone.assert_called_once_with(mode=enginefacade._ASYNC_READER)
         mock_using.assert_called_once_with(ctxt)
 
     @mock.patch.object(enginefacade._TransactionContextManager, 'using')
     @mock.patch.object(enginefacade._TransactionContextManager, '_clone')
-    def test_select_db_reader_mode_no_use_slave_select_sync(self, mock_clone,
+    def test_select_db_reader_mode_no_use_subordinate_select_sync(self, mock_clone,
                                                             mock_using):
 
         @db.select_db_reader_mode
@@ -1120,7 +1120,7 @@ class SqlAlchemyDbApiNoDbTestCase(test.NoDBTestCase):
 
         sqlalchemy_api.get_engine()
         mock_create_facade.assert_called_once_with()
-        mock_facade.get_engine.assert_called_once_with(use_slave=False)
+        mock_facade.get_engine.assert_called_once_with(use_subordinate=False)
 
     def test_get_db_conf_with_connection(self):
         mock_conf_group = mock.MagicMock()

--- a/nova/tests/unit/network/test_api.py
+++ b/nova/tests/unit/network/test_api.py
@@ -160,7 +160,7 @@ class ApiTestCase(test.TestCase):
 
         def fake_instance_get_by_uuid(context, instance_uuid,
                                       columns_to_join=None,
-                                      use_slave=None):
+                                      use_subordinate=None):
             if instance_uuid == orig_instance_uuid:
                 self.assertIn('extra.flavor', columns_to_join)
             return fake_instance.fake_db_instance(uuid=instance_uuid)

--- a/nova/tests/unit/network/test_linux_net.py
+++ b/nova/tests/unit/network/test_linux_net.py
@@ -387,7 +387,7 @@ class LinuxNetworkTestCase(test.NoDBTestCase):
         self.context = context.RequestContext('testuser', 'testproject',
                                               is_admin=True)
 
-        def get_vifs(_context, instance_uuid, use_slave):
+        def get_vifs(_context, instance_uuid, use_subordinate):
             return [vif for vif in vifs if vif['instance_uuid'] ==
                         instance_uuid]
 

--- a/nova/tests/unit/objects/test_instance.py
+++ b/nova/tests/unit/objects/test_instance.py
@@ -387,7 +387,7 @@ class _TestInstanceObject(object):
 
         self.assertRaises(exception.OrphanedObjectError, inst.refresh)
         mock_get.assert_called_once_with(self.context, uuid=inst.uuid,
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
     @mock.patch.object(notifications, 'send_update')
     @mock.patch.object(cells_rpcapi, 'CellsAPI')
@@ -512,7 +512,7 @@ class _TestInstanceObject(object):
         mock_update_and_get.return_value = (old_ref, new_ref)
 
         inst = objects.Instance.get_by_uuid(self.context, old_ref['uuid'],
-                                            use_slave=False)
+                                            use_subordinate=False)
         self.assertEqual('hello', inst.display_name)
         inst.display_name = 'goodbye'
         inst.save()
@@ -1640,7 +1640,7 @@ class _TestInstanceListObject(object):
 
         inst_list = objects.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -1657,7 +1657,7 @@ class _TestInstanceListObject(object):
 
         inst_list = objects.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, expected_attrs=['metadata'],
-            use_slave=False, sort_keys=['uuid'], sort_dirs=['asc'])
+            use_subordinate=False, sort_keys=['uuid'], sort_dirs=['asc'])
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -1678,7 +1678,7 @@ class _TestInstanceListObject(object):
         # Single sort key/direction is set, call non-sorted DB function
         objects.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, sort_key='key', sort_dir='dir',
-            limit=100, marker='uuid', use_slave=True)
+            limit=100, marker='uuid', use_subordinate=True)
         mock_get_by_filters.assert_called_once_with(
             self.context, {'foo': 'bar'}, 'key', 'dir', limit=100,
             marker='uuid', columns_to_join=None)
@@ -1693,7 +1693,7 @@ class _TestInstanceListObject(object):
         # Multiple sort keys/directions are set, call sorted DB function
         objects.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, limit=100, marker='uuid',
-            use_slave=True, sort_keys=['key1', 'key2'],
+            use_subordinate=True, sort_keys=['key1', 'key2'],
             sort_dirs=['dir1', 'dir2'])
         mock_get_by_filters_sort.assert_called_once_with(
             self.context, {'foo': 'bar'}, limit=100,
@@ -1711,7 +1711,7 @@ class _TestInstanceListObject(object):
 
         inst_list = objects.InstanceList.get_by_filters(
             self.context, {'deleted': True, 'cleaned': False}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         self.assertEqual(1, len(inst_list))
         self.assertIsInstance(inst_list.objects[0], instance.Instance)
@@ -1841,7 +1841,7 @@ class _TestInstanceListObject(object):
 
         instances = objects.InstanceList.get_by_host(self.context, 'host',
                                                      expected_attrs=['fault'],
-                                                     use_slave=False)
+                                                     use_subordinate=False)
         self.assertEqual(2, len(instances))
         self.assertEqual(fake_faults['fake-uuid'][0],
                          dict(instances[0].fault))

--- a/nova/tests/unit/objects/test_migration.py
+++ b/nova/tests/unit/objects/test_migration.py
@@ -178,7 +178,7 @@ class _TestMigrationObject(object):
         mock_get.return_value = db_migrations
         migrations = (
             migration.MigrationList.get_unconfirmed_by_dest_compute(
-                ctxt, 'window', 'foo', use_slave=False))
+                ctxt, 'window', 'foo', use_subordinate=False))
         self.assertEqual(2, len(migrations))
         for index, db_migration in enumerate(db_migrations):
             self.compare_obj(migrations[index], db_migration)

--- a/nova/tests/unit/test_fixtures.py
+++ b/nova/tests/unit/test_fixtures.py
@@ -433,7 +433,7 @@ class TestAllServicesCurrentFixture(testtools.TestCase):
         self.assertEqual(123, service_obj.Service.get_minimum_version(
             None, 'nova-compute'))
         mock_db.assert_called_once_with(None, ['nova-compute'],
-                                        use_slave=False)
+                                        use_subordinate=False)
         mock_db.reset_mock()
         compute_rpcapi.LAST_VERSION = 123
         self.useFixture(fixtures.AllServicesCurrent())

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -12681,7 +12681,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
             self.assertEqual(2, mock_info.call_count)
 
         filters = {'uuid': instance_uuids}
-        mock_get.assert_called_once_with(mock.ANY, filters, use_slave=True)
+        mock_get.assert_called_once_with(mock.ANY, filters, use_subordinate=True)
         mock_bdms.assert_called_with(mock.ANY, instance_uuids)
 
     @mock.patch.object(host.Host, "list_instance_domains")
@@ -12791,7 +12791,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         mock_list.assert_called_once_with(only_running=False)
         self.assertEqual(5, get_disk_info.call_count)
         filters = {'uuid': instance_uuids}
-        mock_get.assert_called_once_with(mock.ANY, filters, use_slave=True)
+        mock_get.assert_called_once_with(mock.ANY, filters, use_subordinate=True)
         mock_bdms.assert_called_with(mock.ANY, instance_uuids)
 
     @mock.patch.object(host.Host, "list_instance_domains")

--- a/nova/tests/unit/virt/libvirt/test_imagecache.py
+++ b/nova/tests/unit/virt/libvirt/test_imagecache.py
@@ -663,7 +663,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
                 'soft_deleted': True,
             }
             mock_instance_list.assert_called_once_with(
-                ctxt, filters, expected_attrs=[], use_slave=True)
+                ctxt, filters, expected_attrs=[], use_subordinate=True)
 
     def test_store_swap_image(self):
         image_cache_manager = imagecache.ImageCacheManager()

--- a/nova/tests/unit/virt/xenapi/test_xenapi.py
+++ b/nova/tests/unit/virt/xenapi/test_xenapi.py
@@ -3083,7 +3083,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.aggr = objects.Aggregate(context=self.context, id=1,
                                       **values)
         self.fake_metadata = {pool_states.POOL_FLAG: 'XenAPI',
-                              'master_compute': 'host',
+                              'main_compute': 'host',
                               'availability_zone': 'fake_zone',
                               pool_states.KEY: pool_states.ACTIVE,
                               'host': xenapi_fake.get_record('host',
@@ -3094,18 +3094,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
 
         calls = []
 
-        def pool_add_to_aggregate(context, aggregate, host, slave_info=None):
+        def pool_add_to_aggregate(context, aggregate, host, subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_add_to_aggregate)
         self.stubs.Set(self.conn._pool,
                        "add_to_aggregate",
                        pool_add_to_aggregate)
 
         self.conn.add_to_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                   slave_info="SLAVEINFO")
+                                   subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_add_to_aggregate, calls)
 
@@ -3114,18 +3114,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         calls = []
 
         def pool_remove_from_aggregate(context, aggregate, host,
-                                       slave_info=None):
+                                       subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_remove_from_aggregate)
         self.stubs.Set(self.conn._pool,
                        "remove_from_aggregate",
                        pool_remove_from_aggregate)
 
         self.conn.remove_from_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                        slave_info="SLAVEINFO")
+                                        subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_remove_from_aggregate, calls)
 
@@ -3141,11 +3141,11 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.assertThat(self.fake_metadata,
                         matchers.DictMatches(result.metadata))
 
-    def test_join_slave(self):
-        # Ensure join_slave gets called when the request gets to master.
-        def fake_join_slave(id, compute_uuid, host, url, user, password):
-            fake_join_slave.called = True
-        self.stubs.Set(self.conn._pool, "_join_slave", fake_join_slave)
+    def test_join_subordinate(self):
+        # Ensure join_subordinate gets called when the request gets to main.
+        def fake_join_subordinate(id, compute_uuid, host, url, user, password):
+            fake_join_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_join_subordinate", fake_join_subordinate)
 
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
@@ -3155,7 +3155,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                          user='fake_user',
                                          passwd='fake_pass',
                                          xenhost_uuid='fake_uuid'))
-        self.assertTrue(fake_join_slave.called)
+        self.assertTrue(fake_join_subordinate.called)
 
     def test_add_to_aggregate_first_host(self):
         def fake_pool_set_name_label(self, session, pool_ref, name):
@@ -3195,19 +3195,19 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.conn._pool.remove_from_aggregate,
                           self.context, result, "test_host")
 
-    def test_remove_slave(self):
-        # Ensure eject slave gets called.
-        def fake_eject_slave(id, compute_uuid, host_uuid):
-            fake_eject_slave.called = True
-        self.stubs.Set(self.conn._pool, "_eject_slave", fake_eject_slave)
+    def test_remove_subordinate(self):
+        # Ensure eject subordinate gets called.
+        def fake_eject_subordinate(id, compute_uuid, host_uuid):
+            fake_eject_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_eject_subordinate", fake_eject_subordinate)
 
         self.fake_metadata['host2'] = 'fake_host2_uuid'
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                 metadata=self.fake_metadata, aggr_state=pool_states.ACTIVE)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host2")
-        self.assertTrue(fake_eject_slave.called)
+        self.assertTrue(fake_eject_subordinate.called)
 
-    def test_remove_master_solo(self):
+    def test_remove_main_solo(self):
         # Ensure metadata are cleared after removal.
         def fake_clear_pool(id):
             fake_clear_pool.called = True
@@ -3222,8 +3222,8 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                 pool_states.KEY: pool_states.ACTIVE},
                 matchers.DictMatches(result.metadata))
 
-    def test_remote_master_non_empty_pool(self):
-        # Ensure AggregateError is raised if removing the master.
+    def test_remote_main_non_empty_pool(self):
+        # Ensure AggregateError is raised if removing the main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
 
@@ -3335,7 +3335,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.compute.add_aggregate_host,
                           self.context, host="fake_host",
                           aggregate=self.aggr,
-                          slave_info=None)
+                          subordinate_info=None)
         self.assertEqual(self.aggr.metadata[pool_states.KEY],
                 pool_states.ERROR)
         self.assertEqual(self.aggr.hosts, ['fake_host'])
@@ -3346,16 +3346,16 @@ class MockComputeAPI(object):
         self._mock_calls = []
 
     def add_aggregate_host(self, ctxt, aggregate,
-                                     host_param, host, slave_info):
+                                     host_param, host, subordinate_info):
         self._mock_calls.append((
             self.add_aggregate_host, ctxt, aggregate,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
     def remove_aggregate_host(self, ctxt, host, aggregate_id, host_param,
-                              slave_info):
+                              subordinate_info):
         self._mock_calls.append((
             self.remove_aggregate_host, ctxt, host, aggregate_id,
-            host_param, slave_info))
+            host_param, subordinate_info))
 
 
 class StubDependencies(object):
@@ -3370,10 +3370,10 @@ class StubDependencies(object):
     def _get_metadata(self, *_ignore):
         return {
             pool_states.KEY: {},
-            'master_compute': 'master'
+            'main_compute': 'main'
         }
 
-    def _create_slave_info(self, *ignore):
+    def _create_subordinate_info(self, *ignore):
         return "SLAVE_INFO"
 
 
@@ -3387,33 +3387,33 @@ class HypervisorPoolTestCase(test.NoDBTestCase):
         'id': 98,
         'hosts': [],
         'metadata': {
-            'master_compute': 'master',
+            'main_compute': 'main',
             pool_states.POOL_FLAG: '',
             pool_states.KEY: ''
             }
         }
     fake_aggregate = objects.Aggregate(**fake_aggregate)
 
-    def test_slave_asks_master_to_add_slave_to_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_add_subordinate_to_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.add_to_aggregate("CONTEXT", self.fake_aggregate, "slave")
-
-        self.assertIn(
-            (slave.compute_rpcapi.add_aggregate_host,
-            "CONTEXT", "slave", self.fake_aggregate,
-            "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
-
-    def test_slave_asks_master_to_remove_slave_from_pool(self):
-        slave = ResourcePoolWithStubs()
-
-        slave.remove_from_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.add_to_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.remove_aggregate_host,
-             "CONTEXT", "slave", 98, "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.add_aggregate_host,
+            "CONTEXT", "subordinate", self.fake_aggregate,
+            "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
+
+    def test_subordinate_asks_main_to_remove_subordinate_from_pool(self):
+        subordinate = ResourcePoolWithStubs()
+
+        subordinate.remove_from_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
+
+        self.assertIn(
+            (subordinate.compute_rpcapi.remove_aggregate_host,
+             "CONTEXT", "subordinate", 98, "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
 
 class SwapXapiHostTestCase(test.NoDBTestCase):

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -7091,7 +7091,7 @@ class LibvirtDriver(driver.ComputeDriver):
         # in _update_available_resource method for calculating usages based
         # on instance utilization.
         local_instance_list = objects.InstanceList.get_by_filters(
-            ctx, filters, use_slave=True)
+            ctx, filters, use_subordinate=True)
         # Convert instance list to dictionary with instance uuid as key.
         local_instances = {inst.uuid: inst for inst in local_instance_list}
 

--- a/nova/virt/xenapi/fake.py
+++ b/nova/virt/xenapi/fake.py
@@ -119,7 +119,7 @@ def create_host(name_label, hostname='fake_name', address='fake_addr'):
     # Create a pool if we don't have one already
     if len(_db_content['pool']) == 0:
         pool_ref = _create_pool('')
-        _db_content['pool'][pool_ref]['master'] = host_ref
+        _db_content['pool'][pool_ref]['main'] = host_ref
         _db_content['pool'][pool_ref]['default-SR'] = host_default_sr_ref
         _db_content['pool'][pool_ref]['suspend-image-SR'] = host_default_sr_ref
 
@@ -896,7 +896,7 @@ class SessionBase(object):
             return self._session
         elif name == 'xenapi':
             return _Dispatcher(self.xenapi_request, None)
-        elif name.startswith('login') or name.startswith('slave_local'):
+        elif name.startswith('login') or name.startswith('subordinate_local'):
             return lambda *params: self._login(name, params)
         elif name.startswith('Async'):
             return lambda *params: self._async(name, params)

--- a/nova/virt/xenapi/pool.py
+++ b/nova/virt/xenapi/pool.py
@@ -58,7 +58,7 @@ class ResourcePool(object):
                               'state during operation on %(host)s'),
                           {'aggregate_id': aggregate.id, 'host': host})
 
-    def add_to_aggregate(self, context, aggregate, host, slave_info=None):
+    def add_to_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Add a compute host to an aggregate."""
         if not pool_states.is_hv_pool(aggregate.metadata):
             return
@@ -80,38 +80,38 @@ class ResourcePool(object):
         if (aggregate.metadata[pool_states.KEY] == pool_states.CREATED):
             aggregate.update_metadata({pool_states.KEY: pool_states.CHANGING})
         if len(aggregate.hosts) == 1:
-            # this is the first host of the pool -> make it master
+            # this is the first host of the pool -> make it main
             self._init_pool(aggregate.id, aggregate.name)
-            # save metadata so that we can find the master again
-            metadata = {'master_compute': host,
+            # save metadata so that we can find the main again
+            metadata = {'main_compute': host,
                         host: self._host_uuid,
                         pool_states.KEY: pool_states.ACTIVE}
             aggregate.update_metadata(metadata)
         else:
             # the pool is already up and running, we need to figure out
             # whether we can serve the request from this host or not.
-            master_compute = aggregate.metadata['master_compute']
-            if master_compute == CONF.host and master_compute != host:
-                # this is the master ->  do a pool-join
-                # To this aim, nova compute on the slave has to go down.
+            main_compute = aggregate.metadata['main_compute']
+            if main_compute == CONF.host and main_compute != host:
+                # this is the main ->  do a pool-join
+                # To this aim, nova compute on the subordinate has to go down.
                 # NOTE: it is assumed that ONLY nova compute is running now
-                self._join_slave(aggregate.id, host,
-                                 slave_info.get('compute_uuid'),
-                                 slave_info.get('url'), slave_info.get('user'),
-                                 slave_info.get('passwd'))
-                metadata = {host: slave_info.get('xenhost_uuid'), }
+                self._join_subordinate(aggregate.id, host,
+                                 subordinate_info.get('compute_uuid'),
+                                 subordinate_info.get('url'), subordinate_info.get('user'),
+                                 subordinate_info.get('passwd'))
+                metadata = {host: subordinate_info.get('xenhost_uuid'), }
                 aggregate.update_metadata(metadata)
-            elif master_compute and master_compute != host:
-                # send rpc cast to master, asking to add the following
+            elif main_compute and main_compute != host:
+                # send rpc cast to main, asking to add the following
                 # host with specified credentials.
-                slave_info = self._create_slave_info()
+                subordinate_info = self._create_subordinate_info()
 
                 self.compute_rpcapi.add_aggregate_host(
-                    context, host, aggregate, master_compute, slave_info)
+                    context, host, aggregate, main_compute, subordinate_info)
 
-    def remove_from_aggregate(self, context, aggregate, host, slave_info=None):
+    def remove_from_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Remove a compute host from an aggregate."""
-        slave_info = slave_info or dict()
+        subordinate_info = subordinate_info or dict()
         if not pool_states.is_hv_pool(aggregate.metadata):
             return
 
@@ -123,19 +123,19 @@ class ResourcePool(object):
                     aggregate_id=aggregate.id,
                     reason=invalid[aggregate.metadata[pool_states.KEY]])
 
-        master_compute = aggregate.metadata['master_compute']
-        if master_compute == CONF.host and master_compute != host:
-            # this is the master -> instruct it to eject a host from the pool
+        main_compute = aggregate.metadata['main_compute']
+        if main_compute == CONF.host and main_compute != host:
+            # this is the main -> instruct it to eject a host from the pool
             host_uuid = aggregate.metadata[host]
-            self._eject_slave(aggregate.id,
-                              slave_info.get('compute_uuid'), host_uuid)
+            self._eject_subordinate(aggregate.id,
+                              subordinate_info.get('compute_uuid'), host_uuid)
             aggregate.update_metadata({host: None})
-        elif master_compute == host:
-            # Remove master from its own pool -> destroy pool only if the
-            # master is on its own, otherwise raise fault. Destroying a
-            # pool made only by master is fictional
+        elif main_compute == host:
+            # Remove main from its own pool -> destroy pool only if the
+            # main is on its own, otherwise raise fault. Destroying a
+            # pool made only by main is fictional
             if len(aggregate.hosts) > 1:
-                # NOTE: this could be avoided by doing a master
+                # NOTE: this could be avoided by doing a main
                 # re-election, but this is simpler for now.
                 raise exception.InvalidAggregateActionDelete(
                                     aggregate_id=aggregate.id,
@@ -143,32 +143,32 @@ class ResourcePool(object):
                                              'from the pool; pool not empty')
                                              % host)
             self._clear_pool(aggregate.id)
-            aggregate.update_metadata({'master_compute': None, host: None})
-        elif master_compute and master_compute != host:
-            # A master exists -> forward pool-eject request to master
-            slave_info = self._create_slave_info()
+            aggregate.update_metadata({'main_compute': None, host: None})
+        elif main_compute and main_compute != host:
+            # A main exists -> forward pool-eject request to main
+            subordinate_info = self._create_subordinate_info()
 
             self.compute_rpcapi.remove_aggregate_host(
-                context, host, aggregate.id, master_compute, slave_info)
+                context, host, aggregate.id, main_compute, subordinate_info)
         else:
             # this shouldn't have happened
             raise exception.AggregateError(aggregate_id=aggregate.id,
                                            action='remove_from_aggregate',
                                            reason=_('Unable to eject %s '
-                                           'from the pool; No master found')
+                                           'from the pool; No main found')
                                            % host)
 
-    def _join_slave(self, aggregate_id, host, compute_uuid, url, user, passwd):
-        """Joins a slave into a XenServer resource pool."""
+    def _join_subordinate(self, aggregate_id, host, compute_uuid, url, user, passwd):
+        """Joins a subordinate into a XenServer resource pool."""
         try:
             args = {'compute_uuid': compute_uuid,
                     'url': url,
                     'user': user,
                     'password': passwd,
                     'force': jsonutils.dumps(CONF.xenserver.use_join_force),
-                    'master_addr': self._host_addr,
-                    'master_user': CONF.xenserver.connection_username,
-                    'master_pass': CONF.xenserver.connection_password, }
+                    'main_addr': self._host_addr,
+                    'main_user': CONF.xenserver.connection_username,
+                    'main_pass': CONF.xenserver.connection_password, }
             self._session.call_plugin('xenhost.py', 'host_join', args)
         except self._session.XenAPI.Failure as e:
             LOG.error(_LE("Pool-Join failed: %s"), e)
@@ -177,8 +177,8 @@ class ResourcePool(object):
                                            reason=_('Unable to join %s '
                                                   'in the pool') % host)
 
-    def _eject_slave(self, aggregate_id, compute_uuid, host_uuid):
-        """Eject a slave from a XenServer resource pool."""
+    def _eject_subordinate(self, aggregate_id, compute_uuid, host_uuid):
+        """Eject a subordinate from a XenServer resource pool."""
         try:
             # shutdown nova-compute; if there are other VMs running, e.g.
             # guest instances, the eject will fail. That's a precaution
@@ -217,7 +217,7 @@ class ResourcePool(object):
                                            action='remove_from_aggregate',
                                            reason=six.text_type(e.details))
 
-    def _create_slave_info(self):
+    def _create_subordinate_info(self):
         """XenServer specific info needed to join the hypervisor pool."""
         # replace the address from the xenapi connection url
         # because this might be 169.254.0.1, i.e. xenapi

--- a/nova/virt/xenapi/pool_states.py
+++ b/nova/virt/xenapi/pool_states.py
@@ -25,7 +25,7 @@ cases.
 A 'created' pool becomes 'changing' during the first request of
 adding a host. During a 'changing' status no other requests will be accepted;
 this is to allow the hypervisor layer to instantiate the underlying pool
-without any potential race condition that may incur in master/slave-based
+without any potential race condition that may incur in main/subordinate-based
 configurations. The pool goes into the 'active' state when the underlying
 pool has been correctly instantiated.
 All other operations (e.g. add/remove hosts) that succeed will keep the

--- a/os_brick/tests/initiator/connectors/test_hgst.py
+++ b/os_brick/tests/initiator/connectors/test_hgst.py
@@ -34,7 +34,7 @@ class HGSTConnectorTestCase(test_connector.ConnectorTestCase):
        valid_lft forever preferred_lft forever
     inet6 ::1/128 scope host
        valid_lft forever preferred_lft forever
-2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master
+2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq main
     link/ether 00:25:90:d9:18:08 brd ff:ff:ff:ff:ff:ff
     inet6 fe80::225:90ff:fed9:1808/64 scope link
        valid_lft forever preferred_lft forever


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.